### PR TITLE
Add QcConfig.run option to generate agg flag

### DIFF
--- a/docs/source/examples/QartodTestExample_WaterLevel.ipynb
+++ b/docs/source/examples/QartodTestExample_WaterLevel.ipynb
@@ -159,10 +159,9 @@
     "qc_results =  qc.run(\n",
     "    inp=data[variable_name],\n",
     "    tinp=data['timestamp'],\n",
-    "    zinp=data['z']\n",
+    "    zinp=data['z'],\n",
+    "    gen_agg=True\n",
     ")\n",
-    "all_tests = [qc_results['qartod'][test_name] for test_name in qc_results['qartod'].keys()]\n",
-    "qc_results['qartod']['qc_agg'] = qartod.qartod_compare(all_tests).astype(int)\n",
     "qc_results\n"
    ]
   },
@@ -214,7 +213,7 @@
    "outputs": [],
    "source": [
     "# QC Aggregate flag\n",
-    "plot_results(data, variable_name, qc_results, title, 'qc_agg')"
+    "plot_results(data, variable_name, qc_results, title, 'aggregate_flag')"
    ]
   },
   {


### PR DESCRIPTION
Resolves https://github.com/ioos/ioos_qc/issues/15 for `QcConfig`.

Still outstanding: add option to generate aggregate flag for `NcQcConfig`. That will be in a separate PR.