### PR TITLE
Generate qartod aggregate flag based on config

### DIFF
--- a/docs/source/examples/QartodTestExample_WaterLevel.ipynb
+++ b/docs/source/examples/QartodTestExample_WaterLevel.ipynb
@@ -125,7 +125,8 @@
     "      \"spike_test\": {\n",
     "        \"suspect_threshold\": 0.8,\n",
     "        \"fail_threshold\": 3\n",
-    "      }\n",
+    "      },\n",
+    "      \"aggregate\": {}\n",
     "    }\n",
     "}"
    ]
@@ -159,8 +160,7 @@
     "qc_results =  qc.run(\n",
     "    inp=data[variable_name],\n",
     "    tinp=data['timestamp'],\n",
-    "    zinp=data['z'],\n",
-    "    gen_agg=True\n",
+    "    zinp=data['z']\n",
     ")\n",
     "qc_results\n"
    ]
@@ -213,7 +213,7 @@
    "outputs": [],
    "source": [
     "# QC Aggregate flag\n",
-    "plot_results(data, variable_name, qc_results, title, 'aggregate_flag')"
+    "plot_results(data, variable_name, qc_results, title, 'aggregate')"
    ]
   },
   {

--- a/ioos_qc/config.py
+++ b/ioos_qc/config.py
@@ -84,7 +84,7 @@ class QcConfig(object):
                     testkwargs = { k: v for k, v in testkwargs.items() if k in valid_keywords }
                     results[modu][testname] = runfunc(**testkwargs)  # noqa
 
-            if modu == 'qartod' and  'aggregate' in tests:
+            if modu == 'qartod' and 'aggregate' in tests:
                 results = qartod.aggregate(results)
 
         return results

--- a/ioos_qc/qartod.py
+++ b/ioos_qc/qartod.py
@@ -46,6 +46,15 @@ def mapdates(dates):
             return np.array(dates, dtype='datetime64[ns]')
             
 
+def aggregate(results: dict) -> np.ma.MaskedArray:
+    """
+    Runs qartod_compare against all other qartod tests in results.
+    """
+    all_tests = [results['qartod'][test_name] for test_name in list(results['qartod'])]
+    results['qartod']['aggregate'] = qartod_compare(all_tests)
+    return results
+
+
 def qartod_compare(vectors : Sequence[Sequence[N]]
                    ) -> np.ma.MaskedArray:
     """Aggregates an array of flags by precedence into a single array.

--- a/ioos_qc/qartod.py
+++ b/ioos_qc/qartod.py
@@ -360,8 +360,10 @@ class ClimatologyConfig(object):
 
             # Indexes that align with the Z
             if not isnan(m.zspan):
-                # Only test non-masked values between the min and max
-                z_idx = (~zinp.mask) & (zinp >= m.zspan.minv) & (zinp <= m.zspan.maxv)
+                # Only test non-masked values between the min and max.
+                # Ignore warnings about comparing masked values
+                with np.errstate(invalid='ignore'):
+                    z_idx = (~zinp.mask) & (zinp >= m.zspan.minv) & (zinp <= m.zspan.maxv)
             else:
                 # Only test the values with masked Z, ie values with no Z
                 z_idx = zinp.mask
@@ -369,7 +371,7 @@ class ClimatologyConfig(object):
             # Combine the T and Z indexes
             values_idx = (t_idx & z_idx)
 
-            # Failed and suspect data for this value span. Combining fail_idx or 
+            # Failed and suspect data for this value span. Combining fail_idx or
             # suspect_idx with values_idx represents the subsets of data that should be
             # fail and suspect respectively.
             if not isnan(m.fspan):

--- a/ioos_qc/qartod.py
+++ b/ioos_qc/qartod.py
@@ -44,7 +44,7 @@ def mapdates(dates):
         except Exception:
             # strings work here but we don't advertise that
             return np.array(dates, dtype='datetime64[ns]')
-            
+
 
 def aggregate(results: dict) -> np.ma.MaskedArray:
     """
@@ -228,7 +228,7 @@ class ClimatologyConfig(object):
         zspan: (optional) Vertical (depth) range, in meters positive down
         period: (optional) The unit the tspan argument is in. Defaults to datetime object
                 but can also be any attribute supported by a pandas Timestamp object.
-                See: https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Timestamp.html                    
+                See: https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Timestamp.html
                     * year
                     * week / weekofyear
                     * dayofyear
@@ -339,7 +339,7 @@ class ClimatologyConfig(object):
         # Member spans are applied in order and any data points that fall into
         # more than one member are flagged by each one.
         for m in self._members:
-            
+
             if m.period is not None:
                 # If a period is defined, extract the attribute from the
                 # pd.DatetimeIndex object before comparison. The min and max
@@ -365,7 +365,7 @@ class ClimatologyConfig(object):
             else:
                 # Only test the values with masked Z, ie values with no Z
                 z_idx = zinp.mask
-                
+
             # Combine the T and Z indexes
             values_idx = (t_idx & z_idx)
 
@@ -378,7 +378,7 @@ class ClimatologyConfig(object):
                 fail_idx = np.zeros(inp.size, dtype=bool)
 
             suspect_idx = (inp < m.vspan.minv) | (inp > m.vspan.maxv)
-            
+
             with np.errstate(invalid='ignore'):
                 flag_arr[(values_idx & fail_idx)] = QartodFlags.FAIL
                 flag_arr[(values_idx & ~fail_idx & suspect_idx)] = QartodFlags.SUSPECT

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -93,7 +93,7 @@ class ConfigRunTest(unittest.TestCase):
             r['qartod']['gross_range_test'],
             expected
         )
-        assert 'aggregate_flag' not in r['qartod']
+        assert 'aggregate' not in r['qartod']
 
     def test_run_with_agg(self):
         qc = QcConfig({'qartod': {
@@ -103,7 +103,8 @@ class ConfigRunTest(unittest.TestCase):
             'spike_test': {
                 'suspect_threshold': 3,
                 'fail_threshold': 10,
-            }
+            },
+            'aggregate': {}
         }})
         inp = [-1, 0, 1, 2, 10, 3]
         expected_gross_range = np.array([4, 1, 1, 1, 1, 1])
@@ -111,13 +112,12 @@ class ConfigRunTest(unittest.TestCase):
         expected_agg = np.array([4, 1, 1, 3, 3, 1])
 
         r = qc.run(
-            gen_agg=True,
             inp=inp
         )
 
         npt.assert_array_equal(r['qartod']['gross_range_test'], expected_gross_range)
         npt.assert_array_equal(r['qartod']['spike_test'], expected_spike)
-        npt.assert_array_equal(r['qartod']['aggregate_flag'], expected_agg)
+        npt.assert_array_equal(r['qartod']['aggregate'], expected_agg)
 
     def test_different_kwargs_run(self):
 


### PR DESCRIPTION
https://github.com/ioos/ioos_qc/pull/23 added a `gen_agg` argument to `QcConfig.run`

```
qc = QcConfig({'qartod': {
    'gross_range_test': {
        'fail_span': [0, 12],
    },
    'spike_test': {
        'suspect_threshold': 3,
        'fail_threshold': 10,
    }
}})
inp = [-1, 0, 1, 2, 10, 3]
results = qc.run(
    inp=inp,
    gen_agg=True
)
```

While this works, it is not consistent with the general approach of defining all test configurations in the JSON/YAML object. 

This update moves the `aggregate` to the config object itself:

```
qc = QcConfig({'qartod': {
    'gross_range_test': {
        'fail_span': [0, 12],
    },
    'spike_test': {
        'suspect_threshold': 3,
        'fail_threshold': 10,
    },
    'aggregate': {}
}})
inp = [-1, 0, 1, 2, 10, 3]
r = qc.run(
    inp=inp
)
```

See https://github.com/ioos/ioos_qc/issues/15