### PR TITLE
Climatology updates: bugfixes, add fspan parameter

### DIFF
--- a/tests/test_qartod.py
+++ b/tests/test_qartod.py
@@ -444,6 +444,215 @@ class QartodClimatologyPeriodFullCoverageTest(unittest.TestCase):
         self._run_test(cc)
 
 
+class QartodClimatologyInclusiveRangesTest(unittest.TestCase):
+    # Test that the various configuration spans (tspan, vspan, fspan, zspan) are
+    # inclusive of both endpoints.
+    def setUp(self):
+        self.cc = qartod.ClimatologyConfig()
+        self.cc.add(
+            tspan=(np.datetime64('2019-11-01'), np.datetime64('2020-02-04')),
+            fspan=(40, 70),
+            vspan=(50, 60),
+            zspan=(0, 10)
+        )
+
+    def _run_test(self, test_inputs, expected_result):
+        times, values, depths = zip(*test_inputs)
+        inputs = [
+            values,
+            np.asarray(values, dtype=np.floating),
+            dask_arr(np.asarray(values, dtype=np.floating))
+        ]
+
+        for i in inputs:
+            results = qartod.climatology_test(
+                config=self.cc,
+                tinp=times,
+                inp=i,
+                zinp=depths
+            )
+            npt.assert_array_equal(
+                results,
+                np.ma.array(expected_result)
+            )
+
+    def test_tspan_out_of_range_low(self):
+        test_inputs = [
+            (
+                np.datetime64('2019-10-31'),
+                55,
+                5
+            )
+        ]
+        expected_result=[2]
+        self._run_test(test_inputs, expected_result)
+
+    def test_tspan_minimum(self):
+        test_inputs = [
+            (
+                np.datetime64('2019-11-01'),
+                55,
+                5
+            )
+        ]
+        expected_result=[1]
+        self._run_test(test_inputs, expected_result)
+
+    def test_tspan_maximum(self):
+        test_inputs = [
+            (
+                np.datetime64('2020-02-04'),
+                55,
+                5
+            )
+        ]
+        expected_result=[1]
+        self._run_test(test_inputs, expected_result)
+
+    def test_tspan_out_of_range_high(self):
+        test_inputs = [
+            (
+                np.datetime64('2020-02-05'),
+                55,
+                5
+            )
+        ]
+        expected_result=[2]
+        self._run_test(test_inputs, expected_result)
+
+    def test_vspan_out_of_range_low(self):
+        test_inputs = [
+            (
+                np.datetime64('2020-01-01'),
+                49,
+                5
+            )
+        ]
+        expected_result=[3]
+        self._run_test(test_inputs, expected_result)
+
+    def test_vspan_minimum(self):
+        test_inputs = [
+            (
+                np.datetime64('2020-01-01'),
+                50,
+                5
+            )
+        ]
+        expected_result=[1]
+        self._run_test(test_inputs, expected_result)
+
+    def test_vspan_maximum(self):
+        test_inputs = [
+            (
+                np.datetime64('2020-01-01'),
+                60,
+                5
+            )
+        ]
+        expected_result=[1]
+        self._run_test(test_inputs, expected_result)
+
+    def test_vspan_out_of_range_high(self):
+        test_inputs = [
+            (
+                np.datetime64('2020-01-01'),
+                61,
+                5
+            )
+        ]
+        expected_result=[3]
+        self._run_test(test_inputs, expected_result)
+
+    def test_fspan_out_of_range_low(self):
+        test_inputs = [
+            (
+                np.datetime64('2020-01-01'),
+                30,
+                5
+            )
+        ]
+        expected_result=[4]
+        self._run_test(test_inputs, expected_result)
+
+    def test_fspan_minimum(self):
+        test_inputs = [
+            (
+                np.datetime64('2020-01-01'),
+                40,
+                5
+            )
+        ]
+        expected_result=[3]
+        self._run_test(test_inputs, expected_result)
+
+    def test_fspan_maximum(self):
+        test_inputs = [
+            (
+                np.datetime64('2020-01-01'),
+                70,
+                5
+            )
+        ]
+        expected_result=[3]
+        self._run_test(test_inputs, expected_result)
+
+    def test_fspan_out_of_range_high(self):
+        test_inputs = [
+            (
+                np.datetime64('2020-01-01'),
+                71,
+                5
+            )
+        ]
+        expected_result=[4]
+        self._run_test(test_inputs, expected_result)
+
+    def test_zspan_out_of_range_low(self):
+        test_inputs = [
+            (
+                np.datetime64('2020-01-01'),
+                55,
+                -1
+            )
+        ]
+        expected_result=[2]
+        self._run_test(test_inputs, expected_result)
+
+    def test_zspan_minimum(self):
+        test_inputs = [
+            (
+                np.datetime64('2020-01-01'),
+                55,
+                0
+            )
+        ]
+        expected_result=[1]
+        self._run_test(test_inputs, expected_result)
+
+    def test_zspan_maximum(self):
+        test_inputs = [
+            (
+                np.datetime64('2020-01-01'),
+                55,
+                10
+            )
+        ]
+        expected_result=[1]
+        self._run_test(test_inputs, expected_result)
+
+    def test_zspan_out_of_range_high(self):
+        test_inputs = [
+            (
+                np.datetime64('2020-01-01'),
+                55,
+                11
+            )
+        ]
+        expected_result=[2]
+        self._run_test(test_inputs, expected_result)
+
+
 class QartodClimatologyDepthTest(unittest.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
Replace zipn.any() call with zinp.count() when checking for non-masked depth inputs because zinp.any() will give a false negative for an array where all (non-masked) depths are zero.

Make the checks on the time and depth ranges include the minimum of each members configured range. Previously the maximum was included (<=) but the minimum was excluded (>). To be consistent with the handling of vspan, include both endpoints. (The QARTOD manuals indicate the endpoints are included for vspan.)

Add a fspan parameter to the configuration. Most of the relevant QARTOD manuals specify a climatology test that does not have a fail span, but the Ocean Optics Data QARTOD manual specifies a climatology test with both a valid span and a fail span. To handle this case, the climatology code should support an optional fail span (fspan).