### PR TITLE
attenuated signal: add `min_period` option (alternative to `min_obs`)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,15 +7,19 @@ env:
   global:
     - secure: "Aw4aBCh8vdSucdmJc3u/LyHkjkKK++9r/qPf24Xq/4MqYdnSiKuKkFRdvRF8wqnyca/1UctAJlULta75eB1/3tU/lkLh5n15C8ATYDH/17jCYU/Lh621B1uedP/N56q6FLWFxfRjHONMRxesa33Hr0G+hlQqMWiuwoGGlJQRgFeclhJ0SA1cBE10tQYBsBrph61OpnoMQ413PHpKH1UcCHMRyCLdYJhJ4LF9vCpLq+zULQ+irSwK8L1HjFGGvXulnT2DRodk1QTLYMTpAURUI+q6BSPd0AlWr2liykTJQyv4GawbCpHCHJ4yGjn9HHjb3Rn2iCTT1ij1UC/IlFOmAgN7IYZ1wCrCw3GX6XRL4oD/POSWTw2lOsqGct48qLzECouvv9Qa24QFnwInuWPAprjiKqaC231IWjatChcqAADj6o7X0JwTf7NwmDb/Bgon6BUsSJ7AIGeDmlauXbK2SXaO6mc+gUMAEWov4kOfiZqwk0+wU2LmOKvS/9tcP2PrW87xFHBJ11juIAp/guMhMEUyumXyNVnNdpozE9aYOZ+CehxI7ThiHBcJ+STltQxKEFb/cyPeyY1zt09PH3Mver3pZnXIug+VWffQ/tJS2iGC8ndwwPkEgOTA4bTmDbugjbKN02dVJlMxabz90orrp8haKUC9Aiu54kVp7hgZqx0="
 
-matrix:
+jobs:
   fast_finish: true
   include:
     - python: 3.6
       env: TEST_TARGET=default
     - python: 3.7
       env: TEST_TARGET=default
+    - python: 3.7
+      env: TEST_TARGET=default USE_NUMBA=true
     - python: 3.8
       env: TEST_TARGET=default
+    - python: 3.8
+      env: TEST_TARGET=default USE_NUMBA=true
     - python: 3.8
       env: TEST_TARGET=coding_standards
     - python: 3.8
@@ -65,6 +69,10 @@ install:
 
 script:
   - set -e
+
+  - if [[ -n "${USE_NUMBA}" ]]; then
+      conda install numba ;
+    fi
 
   - if [[ $TEST_TARGET == 'default' ]]; then
       py.test --disable-warnings ;

--- a/docs/source/examples/QartodTestExample_SalinityAttenuation.ipynb
+++ b/docs/source/examples/QartodTestExample_SalinityAttenuation.ipynb
@@ -51,20 +51,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# # Install QC library\n",
-    "# !pip install git+git://github.com/ioos/ioos_qc.git\n",
+    "# Install QC library\n",
+    "!pip install git+git://github.com/ioos/ioos_qc.git\n",
     "\n",
-    "# Alternative installation (install specific branch):\n",
-    "!pip uninstall -y ioos_qc\n",
-    "!pip install git+git://github.com/ioos/ioos_qc.git@attenuated_signal_updates\n",
+    "# # Alternative installation (install specific branch):\n",
+    "# !pip uninstall -y ioos_qc\n",
+    "# !pip install git+git://github.com/ioos/ioos_qc.git@attenuated_signal_updates\n",
     "\n",
     "# # Alternative installation (run with local updates):\n",
     "# !pip uninstall -y ioos_qc\n",
     "# import sys\n",
     "# sys.path.append(str(libdir))\n",
     "    \n",
-    "from ioos_qc.config import QcConfig\n",
-    "from ioos_qc import qartod"
+    "# from ioos_qc.config import QcConfig\n",
+    "# from ioos_qc import qartod"
    ]
   },
   {
@@ -157,12 +157,15 @@
     "time_delta = 3600 * 24.8\n",
     "print(f'window: {time_delta}')\n",
     "\n",
-    "# start QC after a tidal data\n",
-    "# - 24.8 hours of data at 2 minute intervals\n",
-    "min_periods = 24.8*60/2\n",
-    "# panads uses phrase \"min_periods\" to indicate minimum number of observations\n",
-    "# - ioos_qc uses the phrase \"min_obs\"\n",
-    "print(f'min_obs: {min_periods}')"
+    "# start QC after half a tidal day\n",
+    "min_period_secs = time_delta/2\n",
+    "# one obs per minute\n",
+    "min_period_obs = time_delta/2/60\n",
+    "# panadas uses phrase \"min_periods\" to indicate minimum number of observations in the window\n",
+    "# - ioos_qc uses the phrase \"min_period\" to indicate minimum number of seconds in the window\n",
+    "# Depending on your use case, you can define the period in number of observations or number of seconds\n",
+    "print(f'min_period (secs): {min_period_secs}')\n",
+    "print(f'min_period (num obs): {min_period_obs}')"
    ]
   },
   {
@@ -172,7 +175,7 @@
    "outputs": [],
    "source": [
     "# range check\n",
-    "range_data = data.rolling(f'{time_delta}S', min_periods=int(min_periods)).apply(np.ptp, raw=True)\n",
+    "range_data = data.rolling(f'{time_delta}S', min_periods=int(min_period_obs)).apply(np.ptp, raw=True)\n",
     "range_data.plot()"
    ]
   },
@@ -194,7 +197,7 @@
    "outputs": [],
    "source": [
     "# stdev check\n",
-    "stdev_data = data.rolling(f'{time_delta}S', min_periods=int(min_periods)).apply(np.std, raw=True)\n",
+    "stdev_data = data.rolling(f'{time_delta}S', min_periods=int(min_period_obs)).apply(np.std, raw=True)\n",
     "stdev_data.plot()"
    ]
   },
@@ -211,7 +214,7 @@
    "source": [
     "##### Test range\n",
     "\n",
-    "The beginning 743 points (`min_obs`) are marked as \"NOT EVALUATED\" because there is not enough data yet to evaluate whether they are pass or fail.\n",
+    "The beginning 743 points (`min_period`) are marked as \"NOT EVALUATED\" because there is not enough data yet to evaluate whether they are pass or fail.\n",
     "\n",
     "The range of the signal falls so quickly that no points are marked as \"SUSPECT\", but immediately change from \"PASS\" to \"FAIL\"."
    ]
@@ -232,7 +235,7 @@
     "            \"suspect_threshold\": 17.25,\n",
     "            \"fail_threshold\": 15,\n",
     "            \"test_period\": int(time_delta),\n",
-    "            \"min_obs\": int(min_periods),\n",
+    "            \"min_period\": min_period_secs,\n",
     "            \"check_type\": \"range\"\n",
     "      }\n",
     "    }\n",
@@ -273,7 +276,7 @@
     "            \"fail_threshold\": 4.5,\n",
     "            \"check_type\": \"std\",\n",
     "            \"test_period\": int(time_delta),\n",
-    "            \"min_obs\": int(min_periods),\n",
+    "            \"min_period\": min_period_secs,\n",
     "      }\n",
     "    }\n",
     "}\n",
@@ -299,16 +302,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 1. Test results sensitivity to `min_obs`\n",
+    "### 1. Test results sensitivity to `min_period`\n",
     "\n",
-    "The following plots demonstrate the sensitivity of the test results in the beginning of a time series to the selection of `min_obs`. "
+    "The following plots demonstrate the sensitivity of the test results in the beginning of a time series to the selection of `min_period`. "
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### `min_obs`: 0\n",
+    "### `min_period`: 0\n",
     "\n",
     "No observations are marked suspect at the beginning of the time series, but the first 744 observations (the size of the rolling window) are labeled \"FAILING\"."
    ]
@@ -326,7 +329,7 @@
     "            \"fail_threshold\": 4.5,\n",
     "            \"check_type\": \"std\",\n",
     "            \"test_period\": int(time_delta),\n",
-    "            \"min_obs\": 0\n",
+    "            \"min_period\": 0\n",
     "      }\n",
     "    }\n",
     "}\n",
@@ -344,9 +347,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### `min_obs`: 10\n",
+    "### `min_period`: 10min\n",
     "\n",
-    "Only the first 10 observations are marked as NOT EVALUATED, but the remainder of the first 744 samples are labeled as \"FAILING\"."
+    "Only the first 10s observations are marked as NOT EVALUATED, but the remainder of the first 744 samples are labeled as \"FAILING\"."
    ]
   },
   {
@@ -364,7 +367,7 @@
     "            \"fail_threshold\": 4.5,\n",
     "            \"check_type\": \"std\",\n",
     "            \"test_period\": int(time_delta),\n",
-    "            \"min_obs\": 10\n",
+    "            \"min_period\": 10*60\n",
     "      }\n",
     "    }\n",
     "}\n",
@@ -382,7 +385,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### `min_obs`: 100"
+    "### `min_period`: 1h"
    ]
   },
   {
@@ -398,7 +401,7 @@
     "            \"fail_threshold\": 4.5,\n",
     "            \"check_type\": \"std\",\n",
     "            \"test_period\": int(time_delta),\n",
-    "            \"min_obs\": 100\n",
+    "            \"min_period\": 60*60\n",
     "      }\n",
     "    }\n",
     "}\n",
@@ -416,7 +419,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### `min_obs`: 744\n",
+    "### `min_period`: test_period/2\n",
     "\n",
     "The first 744 samples are marked \"NOT EVALUATED\", but none are marked as \"FAILING\"."
    ]
@@ -434,7 +437,7 @@
     "            \"fail_threshold\": 4.5,\n",
     "            \"check_type\": \"std\",\n",
     "            \"test_period\": int(time_delta),\n",
-    "            \"min_obs\": 744\n",
+    "            \"min_period\": int(time_delta/2)\n",
     "      }\n",
     "    }\n",
     "}\n",
@@ -475,7 +478,7 @@
     "            \"fail_threshold\": 4.5,\n",
     "            \"check_type\": \"std\",\n",
     "            \"test_period\": int(time_delta),\n",
-    "            \"min_obs\": 744\n",
+    "            \"min_period\": min_period_secs\n",
     "      }\n",
     "    }\n",
     "}\n",
@@ -509,7 +512,7 @@
     "            \"fail_threshold\": 4.5,\n",
     "            \"check_type\": \"std\",\n",
     "            \"test_period\": int(time_delta),\n",
-    "            \"min_obs\": 744\n",
+    "            \"min_period\": min_period_secs\n",
     "      }\n",
     "    }\n",
     "}\n",
@@ -543,7 +546,7 @@
     "            \"fail_threshold\": 4.5,\n",
     "            \"check_type\": \"std\",\n",
     "            \"test_period\": int(time_delta),\n",
-    "            \"min_obs\": 744\n",
+    "            \"min_period\": min_period_secs\n",
     "      }\n",
     "    }\n",
     "}\n",

--- a/ioos_qc/qartod.py
+++ b/ioos_qc/qartod.py
@@ -731,7 +731,7 @@ def attenuated_signal_test(inp : Sequence[N],
             min_periods = None
         series = pd.Series(inp.flatten(), index=tinp.flatten())
         windows = series.rolling(f'{test_period}s', min_periods=min_periods)
-        check_val = windows.apply(check_func, raw=True)
+        check_val = window_func(windows)
     else:
         # applying np.ptp to Series causes warnings, this is a workaround
         series = inp.flatten()

--- a/tests/test_qartod.py
+++ b/tests/test_qartod.py
@@ -484,7 +484,7 @@ class QartodClimatologyInclusiveRangesTest(unittest.TestCase):
                 5
             )
         ]
-        expected_result=[2]
+        expected_result = [2]
         self._run_test(test_inputs, expected_result)
 
     def test_tspan_minimum(self):
@@ -495,7 +495,7 @@ class QartodClimatologyInclusiveRangesTest(unittest.TestCase):
                 5
             )
         ]
-        expected_result=[1]
+        expected_result = [1]
         self._run_test(test_inputs, expected_result)
 
     def test_tspan_maximum(self):
@@ -506,7 +506,7 @@ class QartodClimatologyInclusiveRangesTest(unittest.TestCase):
                 5
             )
         ]
-        expected_result=[1]
+        expected_result = [1]
         self._run_test(test_inputs, expected_result)
 
     def test_tspan_out_of_range_high(self):
@@ -517,7 +517,7 @@ class QartodClimatologyInclusiveRangesTest(unittest.TestCase):
                 5
             )
         ]
-        expected_result=[2]
+        expected_result = [2]
         self._run_test(test_inputs, expected_result)
 
     def test_vspan_out_of_range_low(self):
@@ -528,7 +528,7 @@ class QartodClimatologyInclusiveRangesTest(unittest.TestCase):
                 5
             )
         ]
-        expected_result=[3]
+        expected_result = [3]
         self._run_test(test_inputs, expected_result)
 
     def test_vspan_minimum(self):
@@ -539,7 +539,7 @@ class QartodClimatologyInclusiveRangesTest(unittest.TestCase):
                 5
             )
         ]
-        expected_result=[1]
+        expected_result = [1]
         self._run_test(test_inputs, expected_result)
 
     def test_vspan_maximum(self):
@@ -550,7 +550,7 @@ class QartodClimatologyInclusiveRangesTest(unittest.TestCase):
                 5
             )
         ]
-        expected_result=[1]
+        expected_result = [1]
         self._run_test(test_inputs, expected_result)
 
     def test_vspan_out_of_range_high(self):
@@ -561,7 +561,7 @@ class QartodClimatologyInclusiveRangesTest(unittest.TestCase):
                 5
             )
         ]
-        expected_result=[3]
+        expected_result = [3]
         self._run_test(test_inputs, expected_result)
 
     def test_fspan_out_of_range_low(self):
@@ -572,7 +572,7 @@ class QartodClimatologyInclusiveRangesTest(unittest.TestCase):
                 5
             )
         ]
-        expected_result=[4]
+        expected_result = [4]
         self._run_test(test_inputs, expected_result)
 
     def test_fspan_minimum(self):
@@ -583,7 +583,7 @@ class QartodClimatologyInclusiveRangesTest(unittest.TestCase):
                 5
             )
         ]
-        expected_result=[3]
+        expected_result = [3]
         self._run_test(test_inputs, expected_result)
 
     def test_fspan_maximum(self):
@@ -594,7 +594,7 @@ class QartodClimatologyInclusiveRangesTest(unittest.TestCase):
                 5
             )
         ]
-        expected_result=[3]
+        expected_result = [3]
         self._run_test(test_inputs, expected_result)
 
     def test_fspan_out_of_range_high(self):
@@ -605,7 +605,7 @@ class QartodClimatologyInclusiveRangesTest(unittest.TestCase):
                 5
             )
         ]
-        expected_result=[4]
+        expected_result = [4]
         self._run_test(test_inputs, expected_result)
 
     def test_zspan_out_of_range_low(self):
@@ -616,7 +616,7 @@ class QartodClimatologyInclusiveRangesTest(unittest.TestCase):
                 -1
             )
         ]
-        expected_result=[2]
+        expected_result = [2]
         self._run_test(test_inputs, expected_result)
 
     def test_zspan_minimum(self):
@@ -627,7 +627,7 @@ class QartodClimatologyInclusiveRangesTest(unittest.TestCase):
                 0
             )
         ]
-        expected_result=[1]
+        expected_result = [1]
         self._run_test(test_inputs, expected_result)
 
     def test_zspan_maximum(self):
@@ -638,7 +638,7 @@ class QartodClimatologyInclusiveRangesTest(unittest.TestCase):
                 10
             )
         ]
-        expected_result=[1]
+        expected_result = [1]
         self._run_test(test_inputs, expected_result)
 
     def test_zspan_out_of_range_high(self):
@@ -649,7 +649,7 @@ class QartodClimatologyInclusiveRangesTest(unittest.TestCase):
                 11
             )
         ]
-        expected_result=[2]
+        expected_result = [2]
         self._run_test(test_inputs, expected_result)
 
 

--- a/tests/test_qartod.py
+++ b/tests/test_qartod.py
@@ -1192,7 +1192,7 @@ class QartodFlatLineTest(unittest.TestCase):
 class QartodAttenuatedSignalTest(unittest.TestCase):
 
     def _run_test(self, times, signal, suspect_threshold, fail_threshold, check_type, expected,
-                  test_period=None, min_obs=None):
+                  test_period=None, min_obs=None, min_period=None):
         npt.assert_array_equal(
             qartod.attenuated_signal_test(
                 inp=signal,
@@ -1201,6 +1201,7 @@ class QartodAttenuatedSignalTest(unittest.TestCase):
                 fail_threshold=fail_threshold,
                 test_period=test_period,
                 min_obs=min_obs,
+                min_period=min_period,
                 check_type=check_type
             ),
             expected
@@ -1216,6 +1217,7 @@ class QartodAttenuatedSignalTest(unittest.TestCase):
                 fail_threshold=fail_threshold,
                 test_period=test_period,
                 min_obs=min_obs,
+                min_period=min_period,
                 check_type=check_type
             ),
             expected
@@ -1300,22 +1302,37 @@ class QartodAttenuatedSignalTest(unittest.TestCase):
         ])
         time_window = 2 * 86400     # 2 days
 
-        def _run_test_time_window(min_obs, expected):
+        def _run_test_time_window(min_obs, min_period, expected):
             self._run_test(times=times, signal=signal,
                            suspect_threshold=100, fail_threshold=10, check_type='range',
                            expected=expected,
                            test_period=time_window,
-                           min_obs=min_obs)
+                           min_obs=min_obs,
+                           min_period=min_period)
 
-        # no min_obs -- initial values should fail
+        # zero min_obs -- initial values should fail
         min_obs = 0
+        min_period = None
         expected = [4, 4, 4, 3, 1]
-        _run_test_time_window(min_obs, expected)
+        _run_test_time_window(min_obs, min_period, expected)
+
+        # zero min_period -- initial values should fail
+        min_obs = None
+        min_period = 0
+        expected = [4, 4, 4, 3, 1]
+        _run_test_time_window(min_obs, min_period, expected)
 
         # min_obs the same size as time_window -- first window should be UNKNOWN
         min_obs = 2     # 2 days (since 1 obs per day)
+        min_period = None
         expected = [2, 4, 4, 3, 1]
-        _run_test_time_window(min_obs, expected)
+        _run_test_time_window(min_obs, min_period, expected)
+
+        # min_period the same size as time_window -- first window should be UNKNOWN
+        min_obs = None
+        min_period = time_window
+        expected = [2, 4, 4, 3, 1]
+        _run_test_time_window(min_obs, min_period, expected)
 
     def test_attenuated_signal_missing(self):
         signal = np.array([None, 2, 3, 4])

--- a/tests/test_qartod_performance.py
+++ b/tests/test_qartod_performance.py
@@ -167,6 +167,18 @@ class QartodPerformanceTest(unittest.TestCase):
         })
         self.perf_test(qc)
 
+    def test_attenuated_signal_with_time_period_test(self):
+        qc = QcConfig({
+            'qartod': {
+                'attenuated_signal_test': {
+                    'suspect_threshold': 5,
+                    'fail_threshold': 2.5,
+                    'test_period': 86400
+                }
+            }
+        })
+        self.perf_test(qc)
+
     def test_qartod_compare(self):
         qc = QcConfig({
             'qartod': {


### PR DESCRIPTION
Exploring the idea of using `min_period` (minimum number of **seconds** in window required to calculate a result) instead of `min_obs` (minimum number of **observations** in window required to calculate a result).

I duplicated the notebook example and checked in the output, so you can view them alongside. This PR is to illustrate this idea, and should NOT be merged in as-is.