### PR TITLE
QARTOD Spike Test: Add an optional second method for detecting spikes. 

### DIFF
--- a/ioos_qc/qartod.py
+++ b/ioos_qc/qartod.py
@@ -525,7 +525,7 @@ def spike_test(inp : Sequence[N],
             "average": Determine if there is a spike at data point n-1 by subtracting
                 the midpoint of n and n-2 and taking the absolute value of this
                 quantity, and checking if it exceeds a low or high threshold.
-            "diff": Determine if there is a spike at data point n by calculating the difference
+            "differential": Determine if there is a spike at data point n by calculating the difference
                 between n and n-1 and n+1 and n variation. To considered, (n - n-1)*(n+1 - n) should
                 be smaller than zero (in opposite direction).
 
@@ -550,7 +550,7 @@ def spike_test(inp : Sequence[N],
 
         # Calculate the (n-1 - ref) difference
         diff = np.abs(inp - ref)
-    elif method is 'diff':
+    elif method is 'differential':
         ref = np.ma.diff(inp)
 
         # Find the minimum variation prior and after the n value
@@ -561,7 +561,7 @@ def spike_test(inp : Sequence[N],
         with np.errstate(invalid='ignore'):
             diff[1:-1][ref[:-1]*ref[1:] >= 0] = 0
     else:
-        raise ValueError('"'+str(method)+'" method is unknown')
+        raise ValueError('"'+str(method)+'" method is unknown, "average" or "differential" methods are available')
 
     # Start with everything as passing (1)
     flag_arr = np.ma.ones(inp.size, dtype='uint8')

--- a/ioos_qc/qartod.py
+++ b/ioos_qc/qartod.py
@@ -504,13 +504,14 @@ def climatology_test(config : Union[ClimatologyConfig, Sequence[Dict[str, Tuple]
                    long_name='Spike Test Quality Flag')
 def spike_test(inp : Sequence[N],
                suspect_threshold: N,
-               fail_threshold: N
+               fail_threshold: N,
+               method='average'
                ) -> np.ma.core.MaskedArray:
     """Check for spikes by checking neighboring data against thresholds
 
     Determine if there is a spike at data point n-1 by subtracting
     the midpoint of n and n-2 and taking the absolute value of this
-    quantity, and checking if it exceeds a low or high threshold.
+    quantity, and checking if it exceeds a low or high threshold (default).
     Values which do not exceed either threshold are flagged GOOD,
     values which exceed the low threshold are flagged SUSPECT,
     and values which exceed the high threshold are flagged FAIL.
@@ -520,6 +521,13 @@ def spike_test(inp : Sequence[N],
         inp: Input data as a numeric numpy array or a list of numbers.
         suspect_threshold: The SUSPECT threshold value, in observations units.
         fail_threshold: The SUSPECT threshold value, in observations units.
+        method [default:'average','diff']: optional input to assign the method used to detect spikes.
+            "average": Determine if there is a spike at data point n-1 by subtracting
+                the midpoint of n and n-2 and taking the absolute value of this
+                quantity, and checking if it exceeds a low or high threshold.
+            "diff": Determine if there is a spike at data point n by calculating the difference
+                between n and n-1 and n+1 and n variation. To considered, (n - n-1)*(n+1 - n) should
+                be smaller than zero (in opposite direction).
 
     Returns:
         A masked array of flag values equal in size to that of the input.
@@ -533,16 +541,30 @@ def spike_test(inp : Sequence[N],
     original_shape = inp.shape
     inp = inp.flatten()
 
-    # Calculate the average of n-2 and n
-    ref = np.zeros(inp.size, dtype=np.float64)
-    ref[1:-1] = (inp[0:-2] + inp[2:]) / 2
-    ref = np.ma.masked_invalid(ref)
+    # Apply different method
+    if method is 'average':
+        # Calculate the average of n-2 and n
+        ref = np.zeros(inp.size, dtype=np.float64)
+        ref[1:-1] = (inp[0:-2] + inp[2:]) / 2
+        ref = np.ma.masked_invalid(ref)
+
+        # Calculate the (n-1 - ref) difference
+        diff = np.abs(inp - ref)
+    elif method is 'diff':
+        ref = np.ma.diff(inp)
+
+        # Find the minimum variation prior and after the n value
+        diff = np.ma.zeros(inp.size, dtype=np.float64)
+        diff[1:-1] = np.minimum(np.abs(ref[:-1]), np.abs(ref[1:]))
+
+        # Make sure that only the record (n) where the difference prior and after are opposite are considered
+        with np.errstate(invalid='ignore'):
+            diff[1:-1][ref[:-1]*ref[1:] >= 0] = 0
+    else:
+        raise ValueError('"'+str(method)+'" method is unknown')
 
     # Start with everything as passing (1)
     flag_arr = np.ma.ones(inp.size, dtype='uint8')
-
-    # Calculate the (n-1 - ref) difference
-    diff = np.abs(inp - ref)
 
     # If n-1 - ref is greater than the low threshold, SUSPECT test
     with np.errstate(invalid='ignore'):

--- a/ioos_qc/utils.py
+++ b/ioos_qc/utils.py
@@ -263,3 +263,10 @@ def great_circle_distance(lat_arr, lon_arr):
     g = Geod(ellps='WGS84')
     _, _, dist[1:] = g.inv(lon_arr[:-1], lat_arr[:-1], lon_arr[1:], lat_arr[1:])
     return dist
+
+
+def distance_from_target(lat, lon, target_lat, target_lon):
+    g = Geod(ellps='WGS84')
+    _, _, dist_to_target = g.inv(lon, lat, target_lon, target_lat)
+    dist_to_target = np.ma.masked_invalid(dist_to_target.astype(np.float64))
+    return dist_to_target

--- a/tests/test_qartod.py
+++ b/tests/test_qartod.py
@@ -117,6 +117,18 @@ class QartodLocationTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             qartod.location_test(lon=70, lat=70, bbox=(1, 2))
 
+        # Wrong target lon
+        with self.assertRaises(ValueError):
+            qartod.location_test(lon=70, lat=70, bbox=(1, 2, 3, 4), target_lon='foo', target_lat=70, target_range=3000)
+
+        # Wrong target lat
+        with self.assertRaises(ValueError):
+            qartod.location_test(lon=70, lat=70, bbox=(1, 2, 3, 4), target_lon=70, target_lat='bad', target_range=3000)
+
+        # Wrong target range
+        with self.assertRaises(ValueError):
+            qartod.location_test(lon=70, lat=70, bbox=(1, 2, 3, 4), target_lon=70, target_lat=70, target_range='300')
+
     def test_location_bbox(self):
         lon = [80,   -78, -71, -79, 500]
         lat = [None,  50,  59,  10, -60]
@@ -155,6 +167,74 @@ class QartodLocationTest(unittest.TestCase):
             np.ma.array([1, 1, 3])
         )
 
+    def test_location_single_target_threshold(self):
+        lon = np.array([-71.05, -71.06, -80.0])
+        lat = np.array([41.0, 41.02, 45.05])
+
+        npt.assert_array_equal(
+            qartod.location_test(lon, lat, target_range=3000.0, target_lon=-71.06, target_lat=41),
+            np.ma.array([1, 1, 3])
+        )
+
+    def test_location_multiple_target_threshold(self):
+        lon = np.array([-71.05, -71.06, -80.0])
+        lat = np.array([41.0, 41.02, 45.05])
+        target_lon = np.array([-71.05, -75.06, -80.0])
+        target_lat = np.array([41.0, 41.02, 45.05])
+
+        npt.assert_array_equal(
+            qartod.location_test(lon, lat, target_range=3000.0, target_lon=target_lon, target_lat=target_lat),
+            np.ma.array([1, 3, 1])
+        )
+
+    def test_location_multiple_target_missing_target(self):
+            lon = np.array([-71.05, -71.06, -80.0, -80.0])
+            lat = np.array([41.0, 41.02, 45.05, 45.05])
+            target_lon = np.array([-71.05, None, -80.0, None])
+            target_lat = np.array([41.0, 41.02, None, None])
+
+            npt.assert_array_equal(
+                qartod.location_test(lon, lat, target_range=3000.0, target_lon=target_lon, target_lat=target_lat),
+                np.ma.array([1, 9, 9, 9])
+            )
+
+    def test_location_target_missing_threshold(self):
+        lon = np.array([-71.05, -71.06, -80.0])
+        lat = np.array([41.0, 41.02, 45.05])
+        target_lon = np.array([-71.05, -75.06, -80.0])
+        target_lat = np.array([41.0, 41.02, 45.05])
+
+        with self.assertRaises(ValueError):
+            qartod.location_test(lon, lat, target_range=None, target_lon=target_lon, target_lat=target_lat)
+        with self.assertRaises(ValueError):
+            qartod.location_test(lon, lat, target_range=None, target_lon=target_lon[0], target_lat=target_lat[0])
+
+    def test_location_target_missing_threshold(self):
+        lon = np.array([-71.05, -71.06, -80.0])
+        lat = np.array([41.0, 41.02, 45.05])
+        target_lon = np.array([-71.05, -75.06, -80.0])
+        target_lat = np.array([41.0, 41.02, 45.05])
+
+        with self.assertRaises(ValueError):
+            qartod.location_test(lon, lat, target_range=3000, target_lat=target_lat)
+        with self.assertRaises(ValueError):
+            qartod.location_test(lon, lat, target_range=None, target_lon=target_lon)
+        with self.assertRaises(ValueError):
+            qartod.location_test(lon, lat, target_range=3000, target_lat=45)
+        with self.assertRaises(ValueError):
+            qartod.location_test(lon, lat, target_range=3000, target_lon=45)
+
+    def test_location_dual_threshold_test(self):
+        lon = np.array([-71.05, -71.06, -80.0, -80.0])
+        lat = np.array([41.0, 41.02, 45.05, 45.05])
+        target_lon = np.array([-71.05, -71.06, -80.0, -80.0])
+        target_lat = np.array([41.0, 41.02, 45.05, 46.05])
+
+        npt.assert_array_equal(
+            qartod.location_test(lon, lat, range_max=3000,
+                                 target_range=3000.0, target_lon=target_lon, target_lat=target_lat),
+            np.ma.array([1, 1, 3, 3])
+        )
 
 class QartodGrossRangeTest(unittest.TestCase):
 

--- a/tests/test_qartod.py
+++ b/tests/test_qartod.py
@@ -1069,6 +1069,69 @@ class QartodSpikeTest(unittest.TestCase):
             )
 
 
+    def test_spike_methods(self):
+        """
+        Test the different input methods and review the different flags expected.
+        """
+        inp = [3, 4.99, 5, 6, 8, 6, 6, 6.75, 6, 6, 5.3, 6, 6, 9, 5, None, 4, 4]
+        suspect_threshold = .5
+        fail_threshold = 1
+        average_method_expected = [2, 3, 1, 1, 4, 3, 1, 3, 1, 1, 3, 1, 4, 4, 4, 9, 9, 2]
+        diff_method_expected = [2, 1, 1, 1, 4, 1, 1, 3, 1, 1, 3, 1, 1, 4, 9, 9, 9, 2]
+
+        # Test average method
+        npt.assert_array_equal(
+            qartod.spike_test(
+                inp=inp,
+                suspect_threshold=suspect_threshold,
+                fail_threshold=fail_threshold,
+                method='average'
+            ),
+            average_method_expected
+        )
+
+        # Test diff method
+        npt.assert_array_equal(
+            qartod.spike_test(
+                inp=inp,
+                suspect_threshold=suspect_threshold,
+                fail_threshold=fail_threshold,
+                method='diff'
+            ),
+            diff_method_expected
+        )
+
+        # Test default method (average)
+        npt.assert_array_equal(
+            qartod.spike_test(
+                inp=inp,
+                suspect_threshold=suspect_threshold,
+                fail_threshold=fail_threshold,
+            ),
+            average_method_expected
+        )
+
+
+    def test_spike_test_bad_method(self):
+        inp = [3, 4.99, 5, 6, 8, 6, 6, 6.75, 6, 6, 5.3, 6, 6, 9, 5, None, 4, 4]
+        suspect_threshold = .5
+        fail_threshold = 1
+
+        with self.assertRaises(ValueError):
+            qartod.spike_test(
+                inp=inp,
+                suspect_threshold=suspect_threshold,
+                fail_threshold=fail_threshold,
+                method='bad'
+            )
+        with self.assertRaises(ValueError):
+            qartod.spike_test(
+                inp=inp,
+                suspect_threshold=suspect_threshold,
+                fail_threshold=fail_threshold,
+                method=123
+            )
+
 class QartodRateOfChangeTest(unittest.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
This PR present an implementation of the spike detection algorithm presented within the issue #48 .

This Pull Request essentially add an optional input **method** to the QARTOD spike test that and add an optionnal differential method for detecting spikes. If not specified, the standard method average method suggested by QARTOD is used.

A series of tests are also added to the test module to handle the different methods and the method input. 