### PR TITLE
QARTOD Spike Test: alternative differential method 

### DIFF
--- a/ioos_qc/qartod.py
+++ b/ioos_qc/qartod.py
@@ -489,7 +489,7 @@ def spike_test(inp: Sequence[N],
     inp = inp.flatten()
 
     # Apply different method
-    if method is 'average':
+    if method == 'average':
         # Calculate the average of n-2 and n
         ref = np.zeros(inp.size, dtype=np.float64)
         ref[1:-1] = (inp[0:-2] + inp[2:]) / 2
@@ -497,7 +497,7 @@ def spike_test(inp: Sequence[N],
 
         # Calculate the (n-1 - ref) difference
         diff = np.abs(inp - ref)
-    elif method is 'differential':
+    elif method == 'differential':
         ref = np.ma.diff(inp)
 
         # Find the minimum variation prior and after the n value
@@ -508,7 +508,8 @@ def spike_test(inp: Sequence[N],
         with np.errstate(invalid='ignore'):
             diff[1:-1][ref[:-1]*ref[1:] >= 0] = 0
     else:
-        raise ValueError('"'+str(method)+'" method is unknown, "average" or "differential" methods are available')
+        raise ValueError('Unknown method: "{0}", only "average" and "differential" methods are available'\
+                         .format(method))
 
     # Start with everything as passing (1)
     flag_arr = np.ma.ones(inp.size, dtype='uint8')

--- a/ioos_qc/qartod.py
+++ b/ioos_qc/qartod.py
@@ -450,8 +450,8 @@ def climatology_test(config : Union[ClimatologyConfig, Sequence[Dict[str, Tuple]
 @add_flag_metadata(standard_name='spike_test_quality_flag',
                    long_name='Spike Test Quality Flag')
 def spike_test(inp: Sequence[N],
-               suspect_threshold: float = None,
-               fail_threshold: float = None,
+               suspect_threshold: N = None,
+               fail_threshold: N = None,
                method: str = 'average'
                ) -> np.ma.core.MaskedArray:
     """Check for spikes by checking neighboring data against thresholds
@@ -515,12 +515,14 @@ def spike_test(inp: Sequence[N],
     flag_arr = np.ma.ones(inp.size, dtype='uint8')
 
     # If n-1 - ref is greater than the low threshold, SUSPECT test
-    with np.errstate(invalid='ignore'):
-        flag_arr[diff > suspect_threshold] = QartodFlags.SUSPECT
+    if suspect_threshold:
+        with np.errstate(invalid='ignore'):
+            flag_arr[diff > suspect_threshold] = QartodFlags.SUSPECT
 
     # If n-1 - ref is greater than the high threshold, FAIL test
-    with np.errstate(invalid='ignore'):
-        flag_arr[diff > fail_threshold] = QartodFlags.FAIL
+    if fail_threshold:
+        with np.errstate(invalid='ignore'):
+            flag_arr[diff > fail_threshold] = QartodFlags.FAIL
 
     # test is undefined for first and last values
     flag_arr[0] = QartodFlags.UNKNOWN

--- a/ioos_qc/qartod.py
+++ b/ioos_qc/qartod.py
@@ -472,7 +472,7 @@ def spike_test(inp : Sequence[N],
             "average": Determine if there is a spike at data point n-1 by subtracting
                 the midpoint of n and n-2 and taking the absolute value of this
                 quantity, and checking if it exceeds a low or high threshold.
-            "diff": Determine if there is a spike at data point n by calculating the difference
+            "differential": Determine if there is a spike at data point n by calculating the difference
                 between n and n-1 and n+1 and n variation. To considered, (n - n-1)*(n+1 - n) should
                 be smaller than zero (in opposite direction).
 
@@ -497,7 +497,7 @@ def spike_test(inp : Sequence[N],
 
         # Calculate the (n-1 - ref) difference
         diff = np.abs(inp - ref)
-    elif method is 'diff':
+    elif method is 'differential':
         ref = np.ma.diff(inp)
 
         # Find the minimum variation prior and after the n value
@@ -508,7 +508,7 @@ def spike_test(inp : Sequence[N],
         with np.errstate(invalid='ignore'):
             diff[1:-1][ref[:-1]*ref[1:] >= 0] = 0
     else:
-        raise ValueError('"'+str(method)+'" method is unknown')
+        raise ValueError('"'+str(method)+'" method is unknown, "average" or "differential" methods are available')
 
     # Start with everything as passing (1)
     flag_arr = np.ma.ones(inp.size, dtype='uint8')

--- a/ioos_qc/qartod.py
+++ b/ioos_qc/qartod.py
@@ -449,10 +449,10 @@ def climatology_test(config : Union[ClimatologyConfig, Sequence[Dict[str, Tuple]
 
 @add_flag_metadata(standard_name='spike_test_quality_flag',
                    long_name='Spike Test Quality Flag')
-def spike_test(inp : Sequence[N],
-               suspect_threshold: N,
-               fail_threshold: N,
-               method='average'
+def spike_test(inp: Sequence[N],
+               suspect_threshold: float = None,
+               fail_threshold: float = None,
+               method: str = 'average'
                ) -> np.ma.core.MaskedArray:
     """Check for spikes by checking neighboring data against thresholds
 
@@ -468,7 +468,7 @@ def spike_test(inp : Sequence[N],
         inp: Input data as a numeric numpy array or a list of numbers.
         suspect_threshold: The SUSPECT threshold value, in observations units.
         fail_threshold: The SUSPECT threshold value, in observations units.
-        method [default:'average','diff']: optional input to assign the method used to detect spikes.
+        method: ['average'(default),'differential'] optional input to assign the method used to detect spikes.
             "average": Determine if there is a spike at data point n-1 by subtracting
                 the midpoint of n and n-2 and taking the absolute value of this
                 quantity, and checking if it exceeds a low or high threshold.

--- a/tests/test_qartod.py
+++ b/tests/test_qartod.py
@@ -989,6 +989,69 @@ class QartodSpikeTest(unittest.TestCase):
             )
 
 
+    def test_spike_methods(self):
+        """
+        Test the different input methods and review the different flags expected.
+        """
+        inp = [3, 4.99, 5, 6, 8, 6, 6, 6.75, 6, 6, 5.3, 6, 6, 9, 5, None, 4, 4]
+        suspect_threshold = .5
+        fail_threshold = 1
+        average_method_expected = [2, 3, 1, 1, 4, 3, 1, 3, 1, 1, 3, 1, 4, 4, 4, 9, 9, 2]
+        diff_method_expected = [2, 1, 1, 1, 4, 1, 1, 3, 1, 1, 3, 1, 1, 4, 9, 9, 9, 2]
+
+        # Test average method
+        npt.assert_array_equal(
+            qartod.spike_test(
+                inp=inp,
+                suspect_threshold=suspect_threshold,
+                fail_threshold=fail_threshold,
+                method='average'
+            ),
+            average_method_expected
+        )
+
+        # Test diff method
+        npt.assert_array_equal(
+            qartod.spike_test(
+                inp=inp,
+                suspect_threshold=suspect_threshold,
+                fail_threshold=fail_threshold,
+                method='diff'
+            ),
+            diff_method_expected
+        )
+
+        # Test default method (average)
+        npt.assert_array_equal(
+            qartod.spike_test(
+                inp=inp,
+                suspect_threshold=suspect_threshold,
+                fail_threshold=fail_threshold,
+            ),
+            average_method_expected
+        )
+
+
+    def test_spike_test_bad_method(self):
+        inp = [3, 4.99, 5, 6, 8, 6, 6, 6.75, 6, 6, 5.3, 6, 6, 9, 5, None, 4, 4]
+        suspect_threshold = .5
+        fail_threshold = 1
+
+        with self.assertRaises(ValueError):
+            qartod.spike_test(
+                inp=inp,
+                suspect_threshold=suspect_threshold,
+                fail_threshold=fail_threshold,
+                method='bad'
+            )
+        with self.assertRaises(ValueError):
+            qartod.spike_test(
+                inp=inp,
+                suspect_threshold=suspect_threshold,
+                fail_threshold=fail_threshold,
+                method=123
+            )
+
 class QartodRateOfChangeTest(unittest.TestCase):
 
     def setUp(self):

--- a/tests/test_qartod.py
+++ b/tests/test_qartod.py
@@ -1052,6 +1052,28 @@ class QartodSpikeTest(unittest.TestCase):
                 method=123
             )
 
+
+    def test_spike_test_inputs(self):
+        inp = [3, 4.99, 5, 6, 8, 6, 6, 6.75, 6, 6, 5.3, 6, 6, 9, 5, None, 4, 4]
+        expected_suspect_only = [2, 3, 1, 1, 3, 3, 1, 3, 1, 1, 3, 1, 3, 3, 3, 9, 9, 2]
+        expected_fail_only = [2, 1, 1, 1, 4, 1, 1, 1, 1, 1, 1, 1, 4, 4, 4, 9, 9, 2]
+        suspect_threshold = .5
+        fail_threshold = 1
+
+        npt.assert_array_equal(
+            qartod.spike_test(
+                inp=inp,
+                suspect_threshold=suspect_threshold,
+            ),
+            expected_suspect_only)
+        npt.assert_array_equal(
+            qartod.spike_test(
+                inp=inp,
+                fail_threshold=fail_threshold,
+            ),
+            expected_fail_only)
+
+
 class QartodRateOfChangeTest(unittest.TestCase):
 
     def setUp(self):

--- a/tests/test_qartod.py
+++ b/tests/test_qartod.py
@@ -1016,7 +1016,7 @@ class QartodSpikeTest(unittest.TestCase):
                 inp=inp,
                 suspect_threshold=suspect_threshold,
                 fail_threshold=fail_threshold,
-                method='diff'
+                method='differential'
             ),
             diff_method_expected
         )


### PR DESCRIPTION
This PR present an implementation of the spike detection algorithm presented within the issue #48 .

This Pull Request essentially add an optional input method to the QARTOD spike test that and add an optional differential method for detecting spikes. If not specified, the standard method average method suggested by QARTOD is used.

A series of tests are also added to the test module to handle the different methods and the method input.