### PR TITLE
Fixed spike_test masked array issue

### DIFF
--- a/ioos_qc/qartod.py
+++ b/ioos_qc/qartod.py
@@ -491,7 +491,7 @@ def spike_test(inp: Sequence[N],
     # Apply different method
     if method == 'average':
         # Calculate the average of n-2 and n
-        ref = np.zeros(inp.size, dtype=np.float64)
+        ref = np.ma.zeros(inp.size, dtype=np.float64)
         ref[1:-1] = (inp[0:-2] + inp[2:]) / 2
         ref = np.ma.masked_invalid(ref)
 

--- a/tests/test_qartod.py
+++ b/tests/test_qartod.py
@@ -943,7 +943,7 @@ class QartodSpikeTest(unittest.TestCase):
 
         # First and last elements should always be good data, unless someone
         # has set a threshold to zero.
-        expected = [2, 4, 4, 4, 1, 3, 1, 1, 9, 9, 4, 4, 4, 9]
+        expected = [2, 4, 4, 4, 1, 3, 1, 9, 9, 9, 4, 4, 9, 9]
 
         inputs = [
             arr,
@@ -995,7 +995,7 @@ class QartodSpikeTest(unittest.TestCase):
         inp = [3, 4.99, 5, 6, 8, 6, 6, 6.75, 6, 6, 5.3, 6, 6, 9, 5, None, 4, 4]
         suspect_threshold = .5
         fail_threshold = 1
-        average_method_expected = [2, 3, 1, 1, 4, 3, 1, 3, 1, 1, 3, 1, 4, 4, 4, 9, 9, 2]
+        average_method_expected = [2, 3, 1, 1, 4, 3, 1, 3, 1, 1, 3, 1, 4, 4, 9, 9, 9, 2]
         diff_method_expected = [2, 1, 1, 1, 4, 1, 1, 3, 1, 1, 3, 1, 1, 4, 9, 9, 9, 2]
 
         # Test average method
@@ -1052,8 +1052,8 @@ class QartodSpikeTest(unittest.TestCase):
 
     def test_spike_test_inputs(self):
         inp = [3, 4.99, 5, 6, 8, 6, 6, 6.75, 6, 6, 5.3, 6, 6, 9, 5, None, 4, 4]
-        expected_suspect_only = [2, 3, 1, 1, 3, 3, 1, 3, 1, 1, 3, 1, 3, 3, 3, 9, 9, 2]
-        expected_fail_only = [2, 1, 1, 1, 4, 1, 1, 1, 1, 1, 1, 1, 4, 4, 4, 9, 9, 2]
+        expected_suspect_only = [2, 3, 1, 1, 3, 3, 1, 3, 1, 1, 3, 1, 3, 3, 9, 9, 9, 2]
+        expected_fail_only = [2, 1, 1, 1, 4, 1, 1, 1, 1, 1, 1, 1, 4, 4, 9, 9, 9, 2]
         suspect_threshold = .5
         fail_threshold = 1
 


### PR DESCRIPTION
Fixed issue in spike_test where the ref array was not getting initialized as a masked array. This was causing some values that should result in a masked restult to use the underlying value stored in the masked array to be using in the calculation resulting in incorrect results.
For example, with the following input:  
[101, 102, --, 104, 105]  
The resulting output should be:  
[2, 9, 9, 9, 2]  
However, with the ref array initialized as a non masked array the following is the result:  
[2, 1, 9, 9, 2]
The affected tests were also updated to reflect the correct behavior.