### PR TITLE
use h5netcdf instead of netCDF4

### DIFF
--- a/ioos_qc/config_creator/get_assets.py
+++ b/ioos_qc/config_creator/get_assets.py
@@ -5,7 +5,8 @@ import shutil
 from pathlib import Path
 from urllib import request
 
-import netCDF4 as nc
+import h5netcdf.legacyapi as nc
+
 import xarray as xr
 from nco import Nco
 

--- a/ioos_qc/stores.py
+++ b/ioos_qc/stores.py
@@ -9,7 +9,7 @@ from importlib import import_module
 
 import numpy as np
 import pandas as pd
-import netCDF4 as nc4
+import h5netcdf.legacyapi as nc4
 
 from ioos_qc.config import Config
 from ioos_qc.qartod import aggregate

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 geojson
 geopandas
-jsonschema
 h5netcdf
+jsonschema
 numba
 numpy>=1.14
 pyproj

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 geojson
 geopandas
 jsonschema
-netCDF4
+h5netcdf
 numba
 numpy>=1.14
 pyproj

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,8 @@ classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Topic :: Scientific/Engineering
     Topic :: Scientific/Engineering :: GIS
     Topic :: Scientific/Engineering :: Information Analysis
@@ -28,7 +30,7 @@ install_requires =
     geojson
     geopandas
     jsonschema
-    netCDF4
+    h5netcdf
     numba
     numpy>=1.14
     pyproj

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,7 +7,7 @@ import simplejson as json
 
 import numpy as np
 import xarray as xr
-import netCDF4 as nc4
+import h5netcdf.legacyapi as nc4
 
 from ioos_qc import utils
 


### PR DESCRIPTION
This is the first step to reduce the dependency on complex binaries. The `h5netcdf` library uses `h5py` to mimic `netCDF4`'s API and, b/c wheels for it are more readily available we can increase the options where we can install `ioos_qc`. See https://github.com/h5netcdf/h5netcdf for more information on the advantages not depending on netcdf-c.


PS: `h5netcdf` is used by many Earth Sciences communities, including `xarray`, so it will be properly maintained and the switch should not bring any headaches.