### PR TITLE
Use geographiclib in lieu of pyproj

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.0.1
+  rev: v4.3.0
   hooks:
     - id: trailing-whitespace
     - id: check-ast

--- a/ioos_qc/utils.py
+++ b/ioos_qc/utils.py
@@ -5,7 +5,7 @@ import logging
 import simplejson as json
 from typing import Any, Union
 from numbers import Real
-from pyproj import Geod
+from geographiclib.geodesic import Geodesic
 from pathlib import Path
 from datetime import date, datetime
 from collections import OrderedDict as odict
@@ -262,6 +262,7 @@ class GeoNumpyDateEncoder(geojson.GeoJSONEncoder):
 
 def great_circle_distance(lat_arr, lon_arr):
     dist = np.ma.zeros(lon_arr.size, dtype=np.float64)
-    g = Geod(ellps='WGS84')
-    _, _, dist[1:] = g.inv(lon_arr[:-1], lat_arr[:-1], lon_arr[1:], lat_arr[1:])
+    positions = list(zip(lat_arr, lon_arr))
+    positions_pairs = list(zip(positions[:-1], positions[1:]))
+    dist[1:] = [Geodesic.WGS84.Inverse(*pair[0], *pair[1])["s12"] for pair in positions_pairs]
     return dist

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
+geographiclib
 geojson
 geopandas
 jsonschema
 netCDF4
 numba
 numpy>=1.14
-pyproj
 ruamel.yaml
 scipy
 shapely

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ install_requires =
     netCDF4
     numba
     numpy>=1.14
-    pyproj
+    geographiclib
     ruamel.yaml
     scipy
     shapely


### PR DESCRIPTION
Geographiclib is a stable, well maintained, and pure python library. We only use pyproj here for the great_distance calculation, so we should be OK with this change.

The results are similar and geographiclib algorithms do not [suffer from this issue](https://github.com/axiom-data-science/pygc/issues/4). See for a poor man's comparison https://nbviewer.org/gist/ocefpaf/7d290f94e5ffec1af560ded41d8c0dd1

Closes #72.

PS: only the doc build is failing. That should be fixed in #73.