### PR TITLE
Attempt to fix issue 86

### DIFF
--- a/ioos_qc/config_creator/config_creator.py
+++ b/ioos_qc/config_creator/config_creator.py
@@ -504,9 +504,8 @@ class QcConfigCreator:
         # - reshape masked y to (ntimes, ...) where ntimes is y.shape[0]
         # - assume that NaNs are same shape through time (i.e. will not work with wetting-drying)
         y_no_nans = y[~np.isnan(y)].reshape(y.shape[0], -1)
-        # CubicSpline require y to the finite and sometimes segfaults when passing an empty list.
         if y_no_nans.size == 0:
-            y_no_nans = np.zeros_like(x)
+            raise ValueError("CubicSpline require y to the finite.")
         spline = CubicSpline(x, y_no_nans, bc_type='periodic')
 
         # Get days of year for independent variable

--- a/ioos_qc/config_creator/config_creator.py
+++ b/ioos_qc/config_creator/config_creator.py
@@ -504,6 +504,9 @@ class QcConfigCreator:
         # - reshape masked y to (ntimes, ...) where ntimes is y.shape[0]
         # - assume that NaNs are same shape through time (i.e. will not work with wetting-drying)
         y_no_nans = y[~np.isnan(y)].reshape(y.shape[0], -1)
+        # CubicSpline require y to the finite and sometimes segfaults when passing an empty list.
+        if y_no_nans.size == 0:
+            y_no_nans = np.zeros_like(x)
         spline = CubicSpline(x, y_no_nans, bc_type='periodic')
 
         # Get days of year for independent variable

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ geojson
 h5netcdf
 jsonschema
 numba
-numpy>=1.14,<=1.22.4
+numpy>=1.14
 pandas
 pyparsing
 ruamel.yaml

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ install_requires =
     geojson
     h5netcdf
     jsonschema
-    numpy>=1.14,<=1.22.4
+    numpy>=1.14
     pandas
     pyparsing
     ruamel.yaml


### PR DESCRIPTION
@kwilcox I believe we were relying on a bug and passing  an empty `y` to `CubicSpline` should return a `ValuError` but instead we just moved the iteration forward. This PR passes zeroes to ensure we have finite elements to start the iteration.