### PR TITLE
correct link to flake8 on github

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
     - id: requirements-txt-fixer
     - id: file-contents-sorter
 
-- repo: https://gitlab.com/pycqa/flake8
+- repo: https://github.com/PyCQA/flake8
   rev: 3.9.2
   hooks:
     - id: flake8


### PR DESCRIPTION
Flake8 moved from gitlab to github

 https://github.com/PyCQA/flake8

https://www.reddit.com/r/Python/comments/yvfww8/flake8_took_down_the_gitlab_repository_in_favor/