### PR TITLE
Climatology Test: Handing masked depths without zspan

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,3 +24,14 @@ repos:
           )$
       args:
         - --ignore-words-list=pres,ba,ot
+
+ci:
+    autofix_commit_msg: |
+        [pre-commit.ci] auto fixes from pre-commit.com hooks
+
+        for more information, see https://pre-commit.ci
+    autofix_prs: false
+    autoupdate_commit_msg: '[pre-commit.ci] pre-commit autoupdate'
+    autoupdate_schedule: monthly
+    skip: []
+    submodules: false

--- a/ioos_qc/qartod.py
+++ b/ioos_qc/qartod.py
@@ -385,12 +385,12 @@ class ClimatologyConfig(object):
                 fail_idx = np.zeros(inp.size, dtype=bool)
 
             suspect_idx = (inp < m.vspan.minv) | (inp > m.vspan.maxv)
-            
+
             with np.errstate(invalid='ignore'):
                 flag_arr[(values_idx & fail_idx)] = QartodFlags.FAIL
                 flag_arr[(values_idx & ~fail_idx & suspect_idx)] = QartodFlags.SUSPECT
                 flag_arr[(values_idx & ~fail_idx & ~suspect_idx)] = QartodFlags.GOOD
-        
+
         # If the value is masked set the flag to MISSING
         flag_arr[inp.mask] = QartodFlags.MISSING
 

--- a/ioos_qc/qartod.py
+++ b/ioos_qc/qartod.py
@@ -372,8 +372,9 @@ class ClimatologyConfig(object):
                 with np.errstate(invalid='ignore'):
                     z_idx = (~zinp.mask) & (zinp >= m.zspan.minv) & (zinp <= m.zspan.maxv)
             else:
-                # Only test the values with masked Z, ie values with no Z
-                z_idx = zinp.mask
+                # If there is no z data in the config, don't try to filter by depth!
+                # Set z_idx to all True to prevent filtering
+                z_idx = np.ones(inp.size, dtype=bool)
 
             # Combine the T and Z indexes
             values_idx = (t_idx & z_idx)

--- a/tests/test_qartod.py
+++ b/tests/test_qartod.py
@@ -720,6 +720,62 @@ class QartodClimatologyDepthTest(unittest.TestCase):
         self._run_test(test_inputs, expected_result)
 
 
+
+class QartodClimatologyMissingTest(unittest.TestCase):
+    def setUp(self):
+        self.cc = qartod.ClimatologyConfig()
+        # different time range, no depth
+        self.cc.add(
+            tspan=(np.datetime64('2021-07'), np.datetime64('2021-09')),
+            vspan=(3.4, 5)
+        )
+
+    def _run_test(self, test_inputs, expected_result):
+        times, values, depths = zip(*test_inputs)
+        inputs = [
+            values,
+            np.asarray(values, dtype=np.float64),
+            dask_arr(np.asarray(values, dtype=np.float64))
+        ]
+
+        for i in inputs:
+            results = qartod.climatology_test(
+                config=self.cc,
+                tinp=times,
+                inp=i,
+                zinp=depths
+            )
+            npt.assert_array_equal(
+                results,
+                np.ma.array(expected_result)
+            )
+
+    def test_climatology_missing_values(self):
+        test_inputs = [
+            # Not missing value or depth, value out of bounds
+            (
+                np.datetime64('2021-07-16'),
+                0,
+                0
+            ),
+            # Missing value and depth
+            (
+                np.datetime64('2021-07-16'),
+                np.nan,
+                np.nan
+            ),
+            # Not missing value and depth, value within bounds
+            (
+                np.datetime64('2021-07-16'),
+                4.16743,
+                0.08931513
+            )
+        ]
+        expected_result = [3, 9, 1]
+        self._run_test(test_inputs, expected_result)
+
+
+
 class QartodClimatologyTest(unittest.TestCase):
 
     def setUp(self):
@@ -859,6 +915,7 @@ class QartodClimatologyTest(unittest.TestCase):
         ]
         expected_result = [1, 1, 1, 3, 3, 3]
         self._run_test(test_inputs, expected_result)
+    
 
 
 class QartodSpikeTest(unittest.TestCase):

--- a/tests/test_qartod.py
+++ b/tests/test_qartod.py
@@ -720,7 +720,6 @@ class QartodClimatologyDepthTest(unittest.TestCase):
         self._run_test(test_inputs, expected_result)
 
 
-
 class QartodClimatologyMissingTest(unittest.TestCase):
     def setUp(self):
         self.cc = qartod.ClimatologyConfig()
@@ -773,7 +772,6 @@ class QartodClimatologyMissingTest(unittest.TestCase):
         ]
         expected_result = [3, 9, 1]
         self._run_test(test_inputs, expected_result)
-
 
 
 class QartodClimatologyTest(unittest.TestCase):
@@ -916,7 +914,6 @@ class QartodClimatologyTest(unittest.TestCase):
         expected_result = [1, 1, 1, 3, 3, 3]
         self._run_test(test_inputs, expected_result)
     
-
 
 class QartodSpikeTest(unittest.TestCase):
 

--- a/tests/test_qartod.py
+++ b/tests/test_qartod.py
@@ -857,7 +857,7 @@ class QartodClimatologyTest(unittest.TestCase):
                 101
             )
         ]
-        expected_result = [1, 1, 1, 3, 3, 2]
+        expected_result = [1, 1, 1, 3, 3, 3]
         self._run_test(test_inputs, expected_result)
 
 

--- a/tests/test_qartod.py
+++ b/tests/test_qartod.py
@@ -913,7 +913,7 @@ class QartodClimatologyTest(unittest.TestCase):
         ]
         expected_result = [1, 1, 1, 3, 3, 3]
         self._run_test(test_inputs, expected_result)
-    
+
 
 class QartodSpikeTest(unittest.TestCase):
 


### PR DESCRIPTION
### Summary
Copied changes from https://github.com/ioos/ioos_qc/pull/104. Added a test to replicate missing values and no `zspan` set scenario https://github.com/ioos/ioos_qc/issues/65#issuecomment-1033141944. Proposed fix is to set MISSING flag at the end of `check()` so it doesn't get overridden by the GOOD flag. 

### Details
* Added new test `QartodClimatologyMissingTest` to `test_qartod.py` to capture scenario described in #65. The scenario is when a user passes an array with a missing data point (which gets masked by `ioos_qc`) and does not set `zspan` (depth range). The result is that the missing value gets flagged w/ 1 (GOOD) instead of 9 (MISSING). 
* `qartod.py` - the change is moving where we set the MISSING flag to the bottom of the `check()` function so that it doesn't get overridden when we set the GOOD flags.

At the start of `check()` we currently set UNKNOWN and MISSING flags
```
# Start with everything as UNKNOWN (2)
flag_arr = np.ma.empty(inp.size, dtype='uint8')
flag_arr.fill(QartodFlags.UNKNOWN)

# If the value is masked set the flag to MISSING
flag_arr[inp.mask] = QartodFlags.MISSING
```

However, in this line near the end of the `check()` function, the slice keeps good data points AND all masked values. And assigns them the `QartodFlags.GOOD` flag which is a value of `1`.
```
flag_arr[(values_idx & ~fail_idx & ~suspect_idx)] = QartodFlags.GOOD
```
We do not want MISSING flags (9) to be overridden with a GOOD flag (1), so assigning the MISSING flags at the end can prevent this.