### PR TITLE
Test against latest python

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
         os: [ubuntu-latest]
         numba: [true, false]
       fail-fast: false


### PR DESCRIPTION
Numba is available up to Python 3.12 and we should be able to test against all supported Python versions now.