### PR TITLE
Fix flagging logic for missing and unknown data in QARTOD spike test

### DIFF
--- a/ioos_qc/qartod.py
+++ b/ioos_qc/qartod.py
@@ -614,15 +614,18 @@ def spike_test(
 
     # Check if the original data was masked
     for i in range(inp.size):
-    
-        # Check if both inp and diff are masked
-        if inp.mask[i] and diff.mask[i]:
+
+       # Check if inp is masked (original data missing)
+        if inp.mask[i]:
             flag_arr[i] = QartodFlags.MISSING
         
-        # Check if either inp or diff is masked
-        elif inp.mask[i] or diff.mask[i]:
+       # Check if diff is masked but not in inp (this indicates that original data is not missing, 
+       # but the data point got masked in diff lines 575-580 due to trying to calculate a value 
+       # using a valid value and a missing value; and because of that, we are not able to apply QARTOD
+       # thus the UNKNOWN flag)
+        elif (diff.mask[i] and not inp.mask[i]):
             flag_arr[i] = QartodFlags.UNKNOWN
-            
+
     return flag_arr.reshape(original_shape)
 
 

--- a/ioos_qc/qartod.py
+++ b/ioos_qc/qartod.py
@@ -612,9 +612,17 @@ def spike_test(
     flag_arr[0] = QartodFlags.UNKNOWN
     flag_arr[-1] = QartodFlags.UNKNOWN
 
-    # If the value is masked or nan set the flag to MISSING
-    flag_arr[diff.mask] = QartodFlags.MISSING
-
+    # Check if the original data was masked
+    for i in range(inp.size):
+    
+        # Check if both inp and diff are masked
+        if inp.mask[i] and diff.mask[i]:
+            flag_arr[i] = QartodFlags.MISSING
+        
+        # Check if either inp or diff is masked
+        elif inp.mask[i] or diff.mask[i]:
+            flag_arr[i] = QartodFlags.UNKNOWN
+            
     return flag_arr.reshape(original_shape)
 
 

--- a/tests/test_qartod.py
+++ b/tests/test_qartod.py
@@ -1018,7 +1018,7 @@ class QartodSpikeTest(unittest.TestCase):
 
         # First and last elements should always be good data, unless someone
         # has set a threshold to zero.
-        expected = [2, 4, 4, 4, 1, 3, 1, 9, 9, 9, 4, 4, 9, 9]
+        expected = [2, 4, 4, 4, 1, 3, 1, 2, 9, 2, 4, 4, 2, 9]
 
         inputs = [
             arr,
@@ -1126,46 +1126,8 @@ class QartodSpikeTest(unittest.TestCase):
         inp = [3, 4.99, 5, 6, 8, 6, 6, 6.75, 6, 6, 5.3, 6, 6, 9, 5, None, 4, 4]
         suspect_threshold = 0.5
         fail_threshold = 1
-        average_method_expected = [
-            2,
-            3,
-            1,
-            1,
-            4,
-            3,
-            1,
-            3,
-            1,
-            1,
-            3,
-            1,
-            4,
-            4,
-            9,
-            9,
-            9,
-            2,
-        ]
-        diff_method_expected = [
-            2,
-            1,
-            1,
-            1,
-            4,
-            1,
-            1,
-            3,
-            1,
-            1,
-            3,
-            1,
-            1,
-            4,
-            9,
-            9,
-            9,
-            2,
-        ]
+        average_method_expected = [2, 3, 1, 1, 4, 3, 1, 3, 1, 1, 3, 1, 4, 4, 2, 9, 2, 2]
+        diff_method_expected = [2, 1, 1, 1, 4, 1, 1, 3, 1, 1, 3, 1, 1, 4, 2, 9, 2, 2]
 
         # Test average method
         npt.assert_array_equal(
@@ -1222,46 +1184,8 @@ class QartodSpikeTest(unittest.TestCase):
 
     def test_spike_test_inputs(self):
         inp = [3, 4.99, 5, 6, 8, 6, 6, 6.75, 6, 6, 5.3, 6, 6, 9, 5, None, 4, 4]
-        expected_suspect_only = [
-            2,
-            3,
-            1,
-            1,
-            3,
-            3,
-            1,
-            3,
-            1,
-            1,
-            3,
-            1,
-            3,
-            3,
-            9,
-            9,
-            9,
-            2,
-        ]
-        expected_fail_only = [
-            2,
-            1,
-            1,
-            1,
-            4,
-            1,
-            1,
-            1,
-            1,
-            1,
-            1,
-            1,
-            4,
-            4,
-            9,
-            9,
-            9,
-            2,
-        ]
+        expected_suspect_only = [2, 3, 1, 1, 3, 3, 1, 3, 1, 1, 3, 1, 3, 3, 2, 9, 2, 2]
+        expected_fail_only = [2, 1, 1, 1, 4, 1, 1, 1, 1, 1, 1, 1, 4, 4, 2, 9, 2, 2]
         suspect_threshold = 0.5
         fail_threshold = 1
 


### PR DESCRIPTION
Related to issue #106 
As per the observations:

**1. Diff results:**
  Here are the diff results calculated using the average method:
  ```
  [35.54251562117366 -- -- 0.0009809673153213794 0.0004743669231928038
   0.0022776381135756196 -- -- -- 4.972008905212988e-05 0.007755656380723508
   0.008936353381891138 0.001787683444078425]
 ```

**2. Flags Assigned:**
  The flags based on these diff results are:
  `[2 9 9 1 1 1 9 9 9 1 1 1 1]`
  It appears that the flags are assigned correctly.


**3. Code for Examining Flags:**
**examining the spike test flag arrays**
```
wf = pd.DataFrame(x, flag_arr, ['salinity'])
print('right column KEYS: ', 'Missing', QartodFlags.MISSING, 'UNKNOWN', QartodFlags.UNKNOWN, '\n')
print(wf)
```

**4. Data and Flags Analysis:**
original dataset x
```
[35.54251562117366 -- 35.5424538572037 35.54400000534482 35.54750808811659
 35.55196490473474 35.55186644512574 -- 35.550779557924486
 35.550198525366476 35.54951805263036 35.5643488926557 35.56130702591726]
```
```
Index 0 : The diff value is valid and meets the criteria for flag 2.
Index 1 : Marked as missing (9), as expected.
Index 2 : Shows a flag of 9 because the diff is masked, indicating missing data.
```

The flags appear to be correctly applied based on the diff results and thresholds.


So as discussed, another check that implemented:
```
compare the values of `diff` and the original dataset `X`. And if `diff has a `nan` value, but on the same index the value is not `nan` in `x` dataset, in this case, flag will be UNKNOWN.
And if both the values are masked, then MISSING flag will be assigned.
```

@ocefpaf @leilabbb