### PR TITLE
Fix for numpy 2.0

### DIFF
--- a/ioos_qc/qartod.py
+++ b/ioos_qc/qartod.py
@@ -835,7 +835,7 @@ def attenuated_signal_test(
     # These are split for performance reasons
     if check_type == "std":
         window_func = lambda x: x.std()  # noqa
-        check_func = np.std
+        check_func = np.ma.std
     elif check_type == "range":
 
         def window_func(w):
@@ -845,7 +845,7 @@ def attenuated_signal_test(
             except (ImportError, TypeError, NumbaTypeError):
                 return w.apply(np.ptp, raw=True)
 
-        check_func = np.ptp
+        check_func = np.ma.ptp
     else:
         msg = f'Check type "{check_type}" is not one of ["std", "range"]'
         raise ValueError(msg)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ geographiclib
 geojson
 h5netcdf
 jsonschema
-numpy>=1.14,<2
+numpy>=1.14
 pandas
 pyparsing
 ruamel.yaml


### PR DESCRIPTION
Looks like the new `np,ptp` will always return NaNs, even for a masked array :-/
I'm using `np.ma` in `std` as well to be on the safe side.