### PR TITLE
Drop Python 3.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,10 +15,9 @@ maintainers = [
   { name = "Kyle Wilcox", email = "kyle@axds.co" },
   { name = "Filipe Fernandes", email = "ocefpaf+ioos_qc@gmail.com" },
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
Python 3.8 reached EoL and we already dropped it from the tests.