### PR TITLE
Remove unused kw

### DIFF
--- a/ioos_qc/qartod.py
+++ b/ioos_qc/qartod.py
@@ -618,9 +618,9 @@ def spike_test(
        # Check if inp is masked (original data missing)
         if inp.mask[i]:
             flag_arr[i] = QartodFlags.MISSING
-        
-       # Check if diff is masked but not in inp (this indicates that original data is not missing, 
-       # but the data point got masked in diff lines 575-580 due to trying to calculate a value 
+
+       # Check if diff is masked but not in inp (this indicates that original data is not missing,
+       # but the data point got masked in diff lines 575-580 due to trying to calculate a value
        # using a valid value and a missing value; and because of that, we are not able to apply QARTOD
        # thus the UNKNOWN flag)
         elif (diff.mask[i] and not inp.mask[i]):
@@ -802,7 +802,6 @@ def attenuated_signal_test(
     min_period: Optional[int] = None,
     check_type: str = "std",
     *args,
-    **kwargs,
 ) -> np.ma.MaskedArray:
     """Check for near-flat-line conditions using a range or standard deviation.
 


### PR DESCRIPTION
Looks like this  `**kwargs` is not used in the function. Removing it and merging this if the tests passes.