### PR TITLE
fix copy-n-pasta

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: pypi
-      url: https://pypi.org/p/xarray_subset_grid/
+      url: https://pypi.org/p/ioos-qc
     permissions:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
     steps:


### PR DESCRIPTION
The publication worked even with this error. No need for a new release.