### PR TITLE
Add timing_gap_test (QARTOD Glider Test 1, Required)

### DIFF
--- a/ioos_qc/qartod.py
+++ b/ioos_qc/qartod.py
@@ -804,32 +804,41 @@ def flat_line_test(
     return flag_arr.reshape(original_shape)
 
 
+@add_flag_metadata(
+    standard_name="timing_gap_test_quality_flag",
+    long_name="Timing/Gap Test Quality Flag",
+)
 def timing_gap_test(
     times: Sequence[str | datetime],
-    max_time_interval: float,
+    suspect_threshold: float,
+    fail_threshold: float,
 ) -> np.ma.MaskedArray:
     """Checks that observations arrive within the expected time window (Test 1).
 
     Checks the time difference between consecutive observations. If the gap
-    exceeds ``max_time_interval``, the later observation is flagged FAIL.
+    exceeds ``suspect_threshold``, the later observation is flagged SUSPECT.
+    If it exceeds ``fail_threshold``, it is flagged FAIL.
     The first observation is always flagged UNKNOWN since there is no
     prior value to compare against.
 
     Parameters
     ----------
-    times : array-like
+    times
         Sequence of timestamps (datetime, numpy datetime64, or ISO strings),
         in chronological order.
-    max_time_interval : int or float
-        Maximum allowable gap between consecutive observations, in seconds.
+    suspect_threshold
+        Maximum allowable gap in seconds before flagging SUSPECT.
+    fail_threshold
+        Maximum allowable gap in seconds before flagging FAIL.
 
     Returns
     -------
     np.ma.MaskedArray
         Flag array of QartodFlags values:
-        - GOOD (1): gap is within the allowed interval
+        - GOOD (1): gap is within suspect_threshold
         - UNKNOWN (2): first observation (no prior to compare)
-        - FAIL (4): gap exceeds max_time_interval
+        - SUSPECT (3): gap exceeds suspect_threshold
+        - FAIL (4): gap exceeds fail_threshold
         - MISSING (9): NaT or None timestamp
 
     References
@@ -837,23 +846,29 @@ def timing_gap_test(
     U.S. IOOS QARTOD Glider Manual, Test 1, p.10
 
     """
-    times = np.asarray(times, dtype="datetime64[ns]")
-    flags = np.full(times.size, QartodFlags.GOOD, dtype="uint8")
+    tinp = mapdates(np.array(times))
 
-    # First point has no prior observation
-    flags[0] = QartodFlags.UNKNOWN
+    original_shape = tinp.shape
+    tinp = tinp.flatten()
 
-    max_delta = np.timedelta64(int(max_time_interval * 1e9), "ns")
+    flag_arr = np.ma.ones(tinp.size, dtype="uint8")
 
-    for i in range(1, len(times)):
-        if np.isnat(times[i]):
-            flags[i] = QartodFlags.MISSING
-        elif np.isnat(times[i - 1]):
-            flags[i] = QartodFlags.UNKNOWN
-        elif (times[i] - times[i - 1]) > max_delta:
-            flags[i] = QartodFlags.FAIL
+    # First point has no previous point to compare against
+    flag_arr[0] = QartodFlags.UNKNOWN
 
-    return np.ma.MaskedArray(flags)
+    # Flag missing timestamps
+    missing = np.isnat(tinp)
+    flag_arr[missing] = QartodFlags.MISSING
+
+    if tinp.size > 1:
+        gaps = np.diff(
+            tinp.astype("datetime64[s]").astype(np.float64),
+        )
+        with np.errstate(invalid="ignore"):
+            flag_arr[1:][gaps > fail_threshold] = QartodFlags.FAIL
+            flag_arr[1:][(gaps > suspect_threshold) & (gaps <= fail_threshold)] = QartodFlags.SUSPECT
+
+    return flag_arr.reshape(original_shape)
 
 
 @add_flag_metadata(

--- a/ioos_qc/qartod.py
+++ b/ioos_qc/qartod.py
@@ -9,7 +9,9 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
+    from datetime import datetime
     from numbers import Real
+    from typing import Union
 
 import numpy as np
 import pandas as pd
@@ -801,6 +803,58 @@ def flat_line_test(
     flag_arr[inp.mask] = QartodFlags.MISSING
 
     return flag_arr.reshape(original_shape)
+
+
+def timing_gap_test(
+    times: Sequence[Union[str, datetime]],
+    max_time_interval: Union[int, float],
+) -> np.ma.MaskedArray:
+    """
+    Checks that observations arrive within the expected time window (Test 1).
+
+    Checks the time difference between consecutive observations. If the gap
+    exceeds ``max_time_interval``, the later observation is flagged FAIL.
+    The first observation is always flagged UNKNOWN since there is no
+    prior value to compare against.
+
+    Parameters
+    ----------
+    times : array-like
+        Sequence of timestamps (datetime, numpy datetime64, or ISO strings),
+        in chronological order.
+    max_time_interval : int or float
+        Maximum allowable gap between consecutive observations, in seconds.
+
+    Returns
+    -------
+    np.ma.MaskedArray
+        Flag array of QartodFlags values:
+        - GOOD (1): gap is within the allowed interval
+        - UNKNOWN (2): first observation (no prior to compare)
+        - FAIL (4): gap exceeds max_time_interval
+        - MISSING (9): NaT or None timestamp
+
+    References
+    ----------
+    U.S. IOOS QARTOD Glider Manual, Test 1, p.10
+    """
+    times = np.asarray(times, dtype="datetime64[ns]")
+    flags = np.full(times.size, QartodFlags.GOOD, dtype="uint8")
+
+    # First point has no prior observation
+    flags[0] = QartodFlags.UNKNOWN
+
+    max_delta = np.timedelta64(int(max_time_interval * 1e9), "ns")
+
+    for i in range(1, len(times)):
+        if np.isnat(times[i]):
+            flags[i] = QartodFlags.MISSING
+        elif np.isnat(times[i - 1]):
+            flags[i] = QartodFlags.UNKNOWN
+        elif (times[i] - times[i - 1]) > max_delta:
+            flags[i] = QartodFlags.FAIL
+
+    return np.ma.MaskedArray(flags)
 
 
 @add_flag_metadata(

--- a/ioos_qc/qartod.py
+++ b/ioos_qc/qartod.py
@@ -11,7 +11,6 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
     from datetime import datetime
     from numbers import Real
-    from typing import Union
 
 import numpy as np
 import pandas as pd
@@ -806,11 +805,10 @@ def flat_line_test(
 
 
 def timing_gap_test(
-    times: Sequence[Union[str, datetime]],
-    max_time_interval: Union[int, float],
+    times: Sequence[str | datetime],
+    max_time_interval: float,
 ) -> np.ma.MaskedArray:
-    """
-    Checks that observations arrive within the expected time window (Test 1).
+    """Checks that observations arrive within the expected time window (Test 1).
 
     Checks the time difference between consecutive observations. If the gap
     exceeds ``max_time_interval``, the later observation is flagged FAIL.
@@ -837,6 +835,7 @@ def timing_gap_test(
     References
     ----------
     U.S. IOOS QARTOD Glider Manual, Test 1, p.10
+
     """
     times = np.asarray(times, dtype="datetime64[ns]")
     flags = np.full(times.size, QartodFlags.GOOD, dtype="uint8")

--- a/tests/test_qartod.py
+++ b/tests/test_qartod.py
@@ -8,6 +8,7 @@ import pandas as pd
 import pytest
 
 from ioos_qc import qartod
+from ioos_qc.qartod import QartodFlags
 
 L = logging.getLogger("ioos_qc")
 L.setLevel(logging.INFO)
@@ -2092,3 +2093,51 @@ class QartodUtilsTests(unittest.TestCase):
             primary_flags,
             np.array([1, 3, 3, 4, 3, 1, 2, 9]),
         )
+
+
+class QartodTimingGapTest(unittest.TestCase):
+
+    def test_gap_within_limit(self):
+        """All gaps within limit should pass."""
+        times = [
+            "2021-01-01T00:00:00",
+            "2021-01-01T01:00:00",
+            "2021-01-01T02:00:00",
+        ]
+        result = qartod.timing_gap_test(times, max_time_interval=3600 * 3)
+        expected = [QartodFlags.UNKNOWN, QartodFlags.GOOD, QartodFlags.GOOD]
+        np.testing.assert_array_equal(result, expected)
+
+    def test_gap_exceeds_limit(self):
+        """Gap exceeding limit should be flagged FAIL."""
+        times = [
+            "2021-01-01T00:00:00",
+            "2021-01-01T01:00:00",
+            "2021-01-01T08:00:00",  # 7 hour gap — should fail
+        ]
+        result = qartod.timing_gap_test(times, max_time_interval=3600 * 3)
+        expected = [QartodFlags.UNKNOWN, QartodFlags.GOOD, QartodFlags.FAIL]
+        np.testing.assert_array_equal(result, expected)
+
+    def test_missing_timestamp(self):
+        """NaT timestamps should be flagged MISSING."""
+        times = np.array(
+            ["2021-01-01T00:00:00", "NaT", "2021-01-01T02:00:00"],
+            dtype="datetime64[ns]",
+        )
+        result = qartod.timing_gap_test(times, max_time_interval=3600 * 3)
+        assert result[1] == QartodFlags.MISSING
+
+    def test_single_observation(self):
+        """Single observation should be flagged UNKNOWN."""
+        result = qartod.timing_gap_test(["2021-01-01T00:00:00"], max_time_interval=3600)
+        assert result[0] == QartodFlags.UNKNOWN
+
+    def test_exact_boundary(self):
+        """Gap exactly equal to max_time_interval should pass."""
+        times = [
+            "2021-01-01T00:00:00",
+            "2021-01-01T01:00:00",  # exactly 3600s
+        ]
+        result = qartod.timing_gap_test(times, max_time_interval=3600)
+        assert result[1] == QartodFlags.GOOD

--- a/tests/test_qartod.py
+++ b/tests/test_qartod.py
@@ -2097,24 +2097,47 @@ class QartodUtilsTests(unittest.TestCase):
 
 class QartodTimingGapTest(unittest.TestCase):
     def test_gap_within_limit(self):
-        """All gaps within limit should pass."""
+        """All gaps within suspect limit should pass."""
         times = [
             "2021-01-01T00:00:00",
             "2021-01-01T01:00:00",
             "2021-01-01T02:00:00",
         ]
-        result = qartod.timing_gap_test(times, max_time_interval=3600 * 3)
+        result = qartod.timing_gap_test(
+            times,
+            suspect_threshold=3600 * 3,
+            fail_threshold=3600 * 6,
+        )
         expected = [QartodFlags.UNKNOWN, QartodFlags.GOOD, QartodFlags.GOOD]
         np.testing.assert_array_equal(result, expected)
 
-    def test_gap_exceeds_limit(self):
-        """Gap exceeding limit should be flagged FAIL."""
+    def test_gap_suspect(self):
+        """Gap exceeding suspect_threshold but within fail_threshold → SUSPECT."""
         times = [
             "2021-01-01T00:00:00",
             "2021-01-01T01:00:00",
-            "2021-01-01T08:00:00",  # 7 hour gap — should fail
+            "2021-01-01T05:00:00",  # 4 hour gap — suspect
         ]
-        result = qartod.timing_gap_test(times, max_time_interval=3600 * 3)
+        result = qartod.timing_gap_test(
+            times,
+            suspect_threshold=3600 * 3,
+            fail_threshold=3600 * 6,
+        )
+        expected = [QartodFlags.UNKNOWN, QartodFlags.GOOD, QartodFlags.SUSPECT]
+        np.testing.assert_array_equal(result, expected)
+
+    def test_gap_exceeds_fail_limit(self):
+        """Gap exceeding fail_threshold should be flagged FAIL."""
+        times = [
+            "2021-01-01T00:00:00",
+            "2021-01-01T01:00:00",
+            "2021-01-01T08:00:00",  # 7 hour gap — fail
+        ]
+        result = qartod.timing_gap_test(
+            times,
+            suspect_threshold=3600 * 3,
+            fail_threshold=3600 * 6,
+        )
         expected = [QartodFlags.UNKNOWN, QartodFlags.GOOD, QartodFlags.FAIL]
         np.testing.assert_array_equal(result, expected)
 
@@ -2124,19 +2147,31 @@ class QartodTimingGapTest(unittest.TestCase):
             ["2021-01-01T00:00:00", "NaT", "2021-01-01T02:00:00"],
             dtype="datetime64[ns]",
         )
-        result = qartod.timing_gap_test(times, max_time_interval=3600 * 3)
+        result = qartod.timing_gap_test(
+            times,
+            suspect_threshold=3600 * 3,
+            fail_threshold=3600 * 6,
+        )
         assert result[1] == QartodFlags.MISSING
 
     def test_single_observation(self):
         """Single observation should be flagged UNKNOWN."""
-        result = qartod.timing_gap_test(["2021-01-01T00:00:00"], max_time_interval=3600)
+        result = qartod.timing_gap_test(
+            ["2021-01-01T00:00:00"],
+            suspect_threshold=3600,
+            fail_threshold=3600 * 3,
+        )
         assert result[0] == QartodFlags.UNKNOWN
 
     def test_exact_boundary(self):
-        """Gap exactly equal to max_time_interval should pass."""
+        """Gap exactly equal to suspect_threshold should pass (GOOD)."""
         times = [
             "2021-01-01T00:00:00",
             "2021-01-01T01:00:00",  # exactly 3600s
         ]
-        result = qartod.timing_gap_test(times, max_time_interval=3600)
+        result = qartod.timing_gap_test(
+            times,
+            suspect_threshold=3600,
+            fail_threshold=3600 * 3,
+        )
         assert result[1] == QartodFlags.GOOD

--- a/tests/test_qartod.py
+++ b/tests/test_qartod.py
@@ -2096,7 +2096,6 @@ class QartodUtilsTests(unittest.TestCase):
 
 
 class QartodTimingGapTest(unittest.TestCase):
-
     def test_gap_within_limit(self):
         """All gaps within limit should pass."""
         times = [


### PR DESCRIPTION
Implements **Test 1 (Timing/Gap Test, Required)** from the [QARTOD Glider QC Manual](https://cdn.ioos.noaa.gov/media/2017/12/Manual-for-QC-of-Glider-Data_05_09_16.pdf) (p.10).

The existing `check_timestamps()` in `utils.py` checks for monotonicity and gaps but returns a `bool`, making it a pre-processing utility rather than a QARTOD-compliant test. This PR adds `timing_gap_test()` which returns a proper flag array consistent with all other tests in `qartod.py`.

**Flags returned:**
- `GOOD (1)` — gap is within `max_time_interval`
- `UNKNOWN (2)` — first observation (no prior to compare)
- `FAIL (4)` — gap exceeds `max_time_interval`
- `MISSING (9)` — `NaT` or missing timestamp

**Tests added:** 5 unit tests covering normal gaps, exceeded gaps, missing timestamps, single observations, and exact boundary conditions.

Contributes to #58 