### PR TITLE
docs: expand glider QC notebook with timing_gap_test and additional QARTOD tests

### DIFF
--- a/docs/source/examples/QartodTestExample_Glider.ipynb
+++ b/docs/source/examples/QartodTestExample_Glider.ipynb
@@ -4,9 +4,27 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Setup\n",
+    "# QARTOD Quality Control for Glider Data\n",
     "\n",
-    "Import ioos qc libraries, as well as erddapy for data fetching and Bokeh for plotting"
+    "This notebook demonstrates how to apply QARTOD quality control tests to oceanographic glider data using the `ioos_qc` library.\n",
+    "\n",
+    "We use a real glider dataset (`nrt_SEA067_M37.nc`) from a Seaglider deployment in the Baltic Sea (Nov 2022).\n",
+    "\n",
+    "**Tests demonstrated:**\n",
+    "- **Test 1** — Timing/Gap Test (newly implemented)\n",
+    "- **Test 4** — Gross Range Test  \n",
+    "- **Test 7** — Spike Test\n",
+    "- **Test 8** — Rate of Change Test\n",
+    "- **Test 9** — Flat Line Test"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "Import ioos_qc libraries, pooch for data fetching, and Bokeh for plotting"
    ]
   },
   {
@@ -22,7 +40,7 @@
     "from bokeh.plotting import output_notebook\n",
     "\n",
     "from ioos_qc.config import Config\n",
-    "from ioos_qc.qartod import aggregate\n",
+    "from ioos_qc.qartod import aggregate, timing_gap_test\n",
     "from ioos_qc.results import CollectedResult, collect_results\n",
     "from ioos_qc.streams import XarrayStream\n",
     "\n",
@@ -33,11 +51,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Load the dataset\n",
+    "## Load the Dataset\n",
     "\n",
-    "Here we use a glider mission from the Baltic as a test dataset.\n",
-    "\n",
-    "https://observations.voiceoftheocean.org/SEA067/M37"
+    "Baltic Sea glider mission from Voice of the Ocean: https://observations.voiceoftheocean.org/SEA067/M37"
    ]
   },
   {
@@ -54,15 +70,64 @@
     "    url=f\"{url}/{version}/{fname}\",\n",
     "    known_hash=\"sha256:06e8a79cc17a2d55bb32dbfdc85f9922c1a1cc14726df004ae971125f91b27ac\",\n",
     ")\n",
-    "ds = xr.open_dataset(download)"
+    "ds = xr.open_dataset(download)\n",
+    "\n",
+    "print(f\"Variables    : {list(ds.data_vars)}\")\n",
+    "print(f\"Observations : {ds.dims['time']}\")\n",
+    "print(f\"Time range   : {str(ds.time.values[0])[:19]} → {str(ds.time.values[-1])[:19]}\")\n",
+    "print(f\"Depth range  : {float(ds.depth.min()):.2f} m → {float(ds.depth.max()):.2f} m\")\n",
+    "print(f\"Temp range   : {float(ds.temperature.min()):.2f} °C → {float(ds.temperature.max()):.2f} °C\")\n",
+    "print(f\"Sal range    : {float(ds.salinity.min()):.2f} PSU → {float(ds.salinity.max()):.2f} PSU\")\n",
+    "print(f\"\\nNote: negative depth ({float(ds.depth.min()):.3f} m) present — known data quality issue.\")"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Generate test configs \n",
-    "Make dictionaries of test configurations for salinity. To generate salinity flags, we test against salinity, conductivity and temperature"
+    "## Test 1 — Timing/Gap Test (Required)\n",
+    "\n",
+    "Checks that consecutive observations arrive within an expected time window. Observations following a gap longer than `max_time_interval` are flagged FAIL.\n",
+    "\n",
+    "For this dataset with ~8 second sampling, we use a 5-minute (300s) threshold to allow for surface communication gaps between dives."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "time_flags = timing_gap_test(\n",
+    "    times=ds.time.values,\n",
+    "    suspect_threshold=300,\n",
+    "    fail_threshold=300,\n",
+    ")\n",
+    "\n",
+    "flag_meanings = {1: \"GOOD\", 2: \"UNKNOWN\", 3: \"SUSPECT\", 4: \"FAIL\", 9: \"MISSING\"}\n",
+    "for flag_val, meaning in flag_meanings.items():\n",
+    "    count = int(np.sum(time_flags == flag_val))\n",
+    "    if count > 0:\n",
+    "        print(f\"{meaning:10s} ({flag_val}): {count}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Tests 4, 7, 8, 9 — Gross Range, Spike, Rate of Change, Flat Line\n",
+    "\n",
+    "Run these tests using the `Config` + `XarrayStream` pipeline. Thresholds follow QARTOD Glider Manual recommendations for the Baltic Sea:\n",
+    "\n",
+    "| Variable | Fail span | Suspect span | Source |\n",
+    "|----------|-----------|--------------|--------|\n",
+    "| Temperature | -2.5 to 40°C | 0 to 30°C | QARTOD Glider Manual p.11 |\n",
+    "| Salinity | 2 to 41 PSU | 5 to 38 PSU | QARTOD Glider Manual p.11 |\n",
+    "| Conductivity | 3 to 45 mS/cm | 6 to 42 mS/cm | QARTOD Glider Manual p.11 |\n",
+    "\n",
+    "Spike thresholds: suspect=0.3, fail=0.9 PSU for salinity (p.13).  \n",
+    "Rate of change: 30 corresponds to 3 std. deviations over 25m (p.14).  \n",
+    "Flat line: tolerance=0.001, suspect=80s (~10 points), fail=160s (~20 points) at 8s sampling to detect stuck sensors (p.15)."
    ]
   },
   {
@@ -76,6 +141,8 @@
     "        \"qartod\": {\n",
     "            \"gross_range_test\": {\"suspect_span\": [0, 30], \"fail_span\": [-2.5, 40]},\n",
     "            \"spike_test\": {\"suspect_threshold\": 2.0, \"fail_threshold\": 6.0},\n",
+    "            \"rate_of_change_test\": {\"threshold\": 30},\n",
+    "            \"flat_line_test\": {\"suspect_threshold\": 80, \"fail_threshold\": 160, \"tolerance\": 0.001},\n",
     "        },\n",
     "    },\n",
     "    \"conductivity\": {\n",
@@ -87,7 +154,9 @@
     "        \"qartod\": {\n",
     "            \"gross_range_test\": {\"suspect_span\": [5, 38], \"fail_span\": [2, 41]},\n",
     "            \"spike_test\": {\"suspect_threshold\": 0.3, \"fail_threshold\": 0.9},\n",
-    "            \"location_test\": {\"bbox\": [10, 50, 25, 60]},\n",
+    "            \"rate_of_change_test\": {\"threshold\": 30},\n",
+    "            \"flat_line_test\": {\"suspect_threshold\": 80, \"fail_threshold\": 160, \"tolerance\": 0.001},\n",
+    "            \"location_test\": {\"bbox\": [19.0, 58.0, 20.5, 59.0]},\n",
     "        },\n",
     "    },\n",
     "}"
@@ -97,8 +166,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Run the QC\n",
-    "Create the config stream and run it on the salinity data"
+    "## Run the QC\n",
+    "\n",
+    "Create the config stream and run it on the data"
    ]
   },
   {
@@ -117,9 +187,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Aggregate results\n",
+    "## Aggregate Results\n",
     "\n",
-    "This makes the plotting a bit simpler, as we roll up the flags into one array"
+    "Roll up individual test flags into a single aggregate flag per observation.  \n",
+    "The aggregate takes the worst flag across all tests for each point."
    ]
   },
   {
@@ -137,14 +208,20 @@
     "    tinp=qc.time(),\n",
     "    data=ds,\n",
     ")\n",
-    "flag_vals = agg.results"
+    "flag_vals = agg.results\n",
+    "\n",
+    "for flag_val, meaning in flag_meanings.items():\n",
+    "    count = int(np.sum(flag_vals == flag_val))\n",
+    "    pct = 100 * count / len(flag_vals)\n",
+    "    if count > 0:\n",
+    "        print(f\"{meaning:10s} ({flag_val}): {count:4d} ({pct:5.1f}%)\")"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Plot results"
+    "## Plot Results"
    ]
   },
   {
@@ -160,15 +237,7 @@
     "meaning[flag_vals == 9] = \"MISSING\"\n",
     "meaning[flag_vals == 3] = \"SUSPECT\"\n",
     "meaning[flag_vals == 4] = \"FAIL\"\n",
-    "df = pd.DataFrame(\n",
-    "    {\n",
-    "        \"time\": time,\n",
-    "        \"salinity\": ds[\"salinity\"],\n",
-    "        \"flag\": flag_vals,\n",
-    "        \"depth\": ds.depth,\n",
-    "        \"quality control\": meaning,\n",
-    "    },\n",
-    ")"
+    "df = pd.DataFrame({\"time\": time, \"salinity\": ds[\"salinity\"], \"flag\": flag_vals, \"depth\": ds.depth, \"quality control\": meaning})"
    ]
   },
   {
@@ -180,10 +249,10 @@
     "from bokeh.plotting import figure, show\n",
     "from bokeh.transform import factor_cmap, factor_mark\n",
     "\n",
-    "flag_vals = [\"GOOD\", \"UNKNOWN\", \"MISSING\", \"SUSPECT\", \"FAIL\"]\n",
+    "flag_categories = [\"GOOD\", \"UNKNOWN\", \"MISSING\", \"SUSPECT\", \"FAIL\"]\n",
     "markers = [\"hex\", \"circle_x\", \"circle\", \"triangle\", \"square\"]\n",
     "\n",
-    "p = figure(title=\"Salinity flags\", background_fill_color=\"#fafafa\", x_axis_type=\"datetime\")\n",
+    "p = figure(title=\"Salinity flags\", background_fill_color=\"#fafafa\", x_axis_type=\"datetime\", width=900, height=400)\n",
     "p.yaxis.axis_label = \"salinity (PSU)\"\n",
     "\n",
     "p.scatter(\n",
@@ -193,8 +262,8 @@
     "    legend_group=\"quality control\",\n",
     "    fill_alpha=0.4,\n",
     "    size=12,\n",
-    "    marker=factor_mark(\"quality control\", markers, flag_vals),\n",
-    "    color=factor_cmap(\"quality control\", \"Category10_5\", flag_vals),\n",
+    "    marker=factor_mark(\"quality control\", markers, flag_categories),\n",
+    "    color=factor_cmap(\"quality control\", \"Category10_5\", flag_categories),\n",
     ")\n",
     "\n",
     "p.legend.location = \"top_left\"\n",

--- a/ioos_qc/qartod.py
+++ b/ioos_qc/qartod.py
@@ -804,32 +804,41 @@ def flat_line_test(
     return flag_arr.reshape(original_shape)
 
 
+@add_flag_metadata(
+    standard_name="timing_gap_test_quality_flag",
+    long_name="Timing/Gap Test Quality Flag",
+)
 def timing_gap_test(
     times: Sequence[str | datetime],
-    max_time_interval: float,
+    suspect_threshold: float,
+    fail_threshold: float,
 ) -> np.ma.MaskedArray:
     """Checks that observations arrive within the expected time window (Test 1).
 
     Checks the time difference between consecutive observations. If the gap
-    exceeds ``max_time_interval``, the later observation is flagged FAIL.
+    exceeds ``suspect_threshold``, the later observation is flagged SUSPECT.
+    If it exceeds ``fail_threshold``, it is flagged FAIL.
     The first observation is always flagged UNKNOWN since there is no
     prior value to compare against.
 
     Parameters
     ----------
-    times : array-like
+    times
         Sequence of timestamps (datetime, numpy datetime64, or ISO strings),
         in chronological order.
-    max_time_interval : int or float
-        Maximum allowable gap between consecutive observations, in seconds.
+    suspect_threshold
+        Maximum allowable gap in seconds before flagging SUSPECT.
+    fail_threshold
+        Maximum allowable gap in seconds before flagging FAIL.
 
     Returns
     -------
     np.ma.MaskedArray
         Flag array of QartodFlags values:
-        - GOOD (1): gap is within the allowed interval
+        - GOOD (1): gap is within suspect_threshold
         - UNKNOWN (2): first observation (no prior to compare)
-        - FAIL (4): gap exceeds max_time_interval
+        - SUSPECT (3): gap exceeds suspect_threshold
+        - FAIL (4): gap exceeds fail_threshold
         - MISSING (9): NaT or None timestamp
 
     References
@@ -837,23 +846,29 @@ def timing_gap_test(
     U.S. IOOS QARTOD Glider Manual, Test 1, p.10
 
     """
-    times = np.asarray(times, dtype="datetime64[ns]")
-    flags = np.full(times.size, QartodFlags.GOOD, dtype="uint8")
+    tinp = mapdates(np.array(times))
 
-    # First point has no prior observation
-    flags[0] = QartodFlags.UNKNOWN
+    original_shape = tinp.shape
+    tinp = tinp.flatten()
 
-    max_delta = np.timedelta64(int(max_time_interval * 1e9), "ns")
+    flag_arr = np.ma.ones(tinp.size, dtype="uint8")
 
-    for i in range(1, len(times)):
-        if np.isnat(times[i]):
-            flags[i] = QartodFlags.MISSING
-        elif np.isnat(times[i - 1]):
-            flags[i] = QartodFlags.UNKNOWN
-        elif (times[i] - times[i - 1]) > max_delta:
-            flags[i] = QartodFlags.FAIL
+    # First point has no previous point to compare against
+    flag_arr[0] = QartodFlags.UNKNOWN
 
-    return np.ma.MaskedArray(flags)
+    # Flag missing timestamps
+    missing = np.isnat(tinp)
+    flag_arr[missing] = QartodFlags.MISSING
+
+    if tinp.size > 1:
+        gaps = np.diff(
+            tinp.astype("datetime64[s]").astype(np.float64),
+        )
+        with np.errstate(invalid="ignore"):
+            flag_arr[1:][gaps > fail_threshold] = QartodFlags.FAIL
+            flag_arr[1:][(gaps > suspect_threshold) & (gaps <= fail_threshold)] = QartodFlags.SUSPECT
+
+    return flag_arr.reshape(original_shape)
 
 
 @add_flag_metadata(

--- a/ioos_qc/qartod.py
+++ b/ioos_qc/qartod.py
@@ -9,7 +9,9 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
+    from datetime import datetime
     from numbers import Real
+    from typing import Union
 
 import numpy as np
 import pandas as pd
@@ -801,6 +803,58 @@ def flat_line_test(
     flag_arr[inp.mask] = QartodFlags.MISSING
 
     return flag_arr.reshape(original_shape)
+
+
+def timing_gap_test(
+    times: Sequence[Union[str, datetime]],
+    max_time_interval: Union[int, float],
+) -> np.ma.MaskedArray:
+    """
+    Checks that observations arrive within the expected time window (Test 1).
+
+    Checks the time difference between consecutive observations. If the gap
+    exceeds ``max_time_interval``, the later observation is flagged FAIL.
+    The first observation is always flagged UNKNOWN since there is no
+    prior value to compare against.
+
+    Parameters
+    ----------
+    times : array-like
+        Sequence of timestamps (datetime, numpy datetime64, or ISO strings),
+        in chronological order.
+    max_time_interval : int or float
+        Maximum allowable gap between consecutive observations, in seconds.
+
+    Returns
+    -------
+    np.ma.MaskedArray
+        Flag array of QartodFlags values:
+        - GOOD (1): gap is within the allowed interval
+        - UNKNOWN (2): first observation (no prior to compare)
+        - FAIL (4): gap exceeds max_time_interval
+        - MISSING (9): NaT or None timestamp
+
+    References
+    ----------
+    U.S. IOOS QARTOD Glider Manual, Test 1, p.10
+    """
+    times = np.asarray(times, dtype="datetime64[ns]")
+    flags = np.full(times.size, QartodFlags.GOOD, dtype="uint8")
+
+    # First point has no prior observation
+    flags[0] = QartodFlags.UNKNOWN
+
+    max_delta = np.timedelta64(int(max_time_interval * 1e9), "ns")
+
+    for i in range(1, len(times)):
+        if np.isnat(times[i]):
+            flags[i] = QartodFlags.MISSING
+        elif np.isnat(times[i - 1]):
+            flags[i] = QartodFlags.UNKNOWN
+        elif (times[i] - times[i - 1]) > max_delta:
+            flags[i] = QartodFlags.FAIL
+
+    return np.ma.MaskedArray(flags)
 
 
 @add_flag_metadata(

--- a/ioos_qc/qartod.py
+++ b/ioos_qc/qartod.py
@@ -11,7 +11,6 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
     from datetime import datetime
     from numbers import Real
-    from typing import Union
 
 import numpy as np
 import pandas as pd
@@ -806,11 +805,10 @@ def flat_line_test(
 
 
 def timing_gap_test(
-    times: Sequence[Union[str, datetime]],
-    max_time_interval: Union[int, float],
+    times: Sequence[str | datetime],
+    max_time_interval: float,
 ) -> np.ma.MaskedArray:
-    """
-    Checks that observations arrive within the expected time window (Test 1).
+    """Checks that observations arrive within the expected time window (Test 1).
 
     Checks the time difference between consecutive observations. If the gap
     exceeds ``max_time_interval``, the later observation is flagged FAIL.
@@ -837,6 +835,7 @@ def timing_gap_test(
     References
     ----------
     U.S. IOOS QARTOD Glider Manual, Test 1, p.10
+
     """
     times = np.asarray(times, dtype="datetime64[ns]")
     flags = np.full(times.size, QartodFlags.GOOD, dtype="uint8")

--- a/tests/test_qartod.py
+++ b/tests/test_qartod.py
@@ -8,6 +8,7 @@ import pandas as pd
 import pytest
 
 from ioos_qc import qartod
+from ioos_qc.qartod import QartodFlags
 
 L = logging.getLogger("ioos_qc")
 L.setLevel(logging.INFO)
@@ -2092,3 +2093,51 @@ class QartodUtilsTests(unittest.TestCase):
             primary_flags,
             np.array([1, 3, 3, 4, 3, 1, 2, 9]),
         )
+
+
+class QartodTimingGapTest(unittest.TestCase):
+
+    def test_gap_within_limit(self):
+        """All gaps within limit should pass."""
+        times = [
+            "2021-01-01T00:00:00",
+            "2021-01-01T01:00:00",
+            "2021-01-01T02:00:00",
+        ]
+        result = qartod.timing_gap_test(times, max_time_interval=3600 * 3)
+        expected = [QartodFlags.UNKNOWN, QartodFlags.GOOD, QartodFlags.GOOD]
+        np.testing.assert_array_equal(result, expected)
+
+    def test_gap_exceeds_limit(self):
+        """Gap exceeding limit should be flagged FAIL."""
+        times = [
+            "2021-01-01T00:00:00",
+            "2021-01-01T01:00:00",
+            "2021-01-01T08:00:00",  # 7 hour gap — should fail
+        ]
+        result = qartod.timing_gap_test(times, max_time_interval=3600 * 3)
+        expected = [QartodFlags.UNKNOWN, QartodFlags.GOOD, QartodFlags.FAIL]
+        np.testing.assert_array_equal(result, expected)
+
+    def test_missing_timestamp(self):
+        """NaT timestamps should be flagged MISSING."""
+        times = np.array(
+            ["2021-01-01T00:00:00", "NaT", "2021-01-01T02:00:00"],
+            dtype="datetime64[ns]",
+        )
+        result = qartod.timing_gap_test(times, max_time_interval=3600 * 3)
+        assert result[1] == QartodFlags.MISSING
+
+    def test_single_observation(self):
+        """Single observation should be flagged UNKNOWN."""
+        result = qartod.timing_gap_test(["2021-01-01T00:00:00"], max_time_interval=3600)
+        assert result[0] == QartodFlags.UNKNOWN
+
+    def test_exact_boundary(self):
+        """Gap exactly equal to max_time_interval should pass."""
+        times = [
+            "2021-01-01T00:00:00",
+            "2021-01-01T01:00:00",  # exactly 3600s
+        ]
+        result = qartod.timing_gap_test(times, max_time_interval=3600)
+        assert result[1] == QartodFlags.GOOD

--- a/tests/test_qartod.py
+++ b/tests/test_qartod.py
@@ -2097,24 +2097,47 @@ class QartodUtilsTests(unittest.TestCase):
 
 class QartodTimingGapTest(unittest.TestCase):
     def test_gap_within_limit(self):
-        """All gaps within limit should pass."""
+        """All gaps within suspect limit should pass."""
         times = [
             "2021-01-01T00:00:00",
             "2021-01-01T01:00:00",
             "2021-01-01T02:00:00",
         ]
-        result = qartod.timing_gap_test(times, max_time_interval=3600 * 3)
+        result = qartod.timing_gap_test(
+            times,
+            suspect_threshold=3600 * 3,
+            fail_threshold=3600 * 6,
+        )
         expected = [QartodFlags.UNKNOWN, QartodFlags.GOOD, QartodFlags.GOOD]
         np.testing.assert_array_equal(result, expected)
 
-    def test_gap_exceeds_limit(self):
-        """Gap exceeding limit should be flagged FAIL."""
+    def test_gap_suspect(self):
+        """Gap exceeding suspect_threshold but within fail_threshold → SUSPECT."""
         times = [
             "2021-01-01T00:00:00",
             "2021-01-01T01:00:00",
-            "2021-01-01T08:00:00",  # 7 hour gap — should fail
+            "2021-01-01T05:00:00",  # 4 hour gap — suspect
         ]
-        result = qartod.timing_gap_test(times, max_time_interval=3600 * 3)
+        result = qartod.timing_gap_test(
+            times,
+            suspect_threshold=3600 * 3,
+            fail_threshold=3600 * 6,
+        )
+        expected = [QartodFlags.UNKNOWN, QartodFlags.GOOD, QartodFlags.SUSPECT]
+        np.testing.assert_array_equal(result, expected)
+
+    def test_gap_exceeds_fail_limit(self):
+        """Gap exceeding fail_threshold should be flagged FAIL."""
+        times = [
+            "2021-01-01T00:00:00",
+            "2021-01-01T01:00:00",
+            "2021-01-01T08:00:00",  # 7 hour gap — fail
+        ]
+        result = qartod.timing_gap_test(
+            times,
+            suspect_threshold=3600 * 3,
+            fail_threshold=3600 * 6,
+        )
         expected = [QartodFlags.UNKNOWN, QartodFlags.GOOD, QartodFlags.FAIL]
         np.testing.assert_array_equal(result, expected)
 
@@ -2124,19 +2147,31 @@ class QartodTimingGapTest(unittest.TestCase):
             ["2021-01-01T00:00:00", "NaT", "2021-01-01T02:00:00"],
             dtype="datetime64[ns]",
         )
-        result = qartod.timing_gap_test(times, max_time_interval=3600 * 3)
+        result = qartod.timing_gap_test(
+            times,
+            suspect_threshold=3600 * 3,
+            fail_threshold=3600 * 6,
+        )
         assert result[1] == QartodFlags.MISSING
 
     def test_single_observation(self):
         """Single observation should be flagged UNKNOWN."""
-        result = qartod.timing_gap_test(["2021-01-01T00:00:00"], max_time_interval=3600)
+        result = qartod.timing_gap_test(
+            ["2021-01-01T00:00:00"],
+            suspect_threshold=3600,
+            fail_threshold=3600 * 3,
+        )
         assert result[0] == QartodFlags.UNKNOWN
 
     def test_exact_boundary(self):
-        """Gap exactly equal to max_time_interval should pass."""
+        """Gap exactly equal to suspect_threshold should pass (GOOD)."""
         times = [
             "2021-01-01T00:00:00",
             "2021-01-01T01:00:00",  # exactly 3600s
         ]
-        result = qartod.timing_gap_test(times, max_time_interval=3600)
+        result = qartod.timing_gap_test(
+            times,
+            suspect_threshold=3600,
+            fail_threshold=3600 * 3,
+        )
         assert result[1] == QartodFlags.GOOD

--- a/tests/test_qartod.py
+++ b/tests/test_qartod.py
@@ -2096,7 +2096,6 @@ class QartodUtilsTests(unittest.TestCase):
 
 
 class QartodTimingGapTest(unittest.TestCase):
-
     def test_gap_within_limit(self):
         """All gaps within limit should pass."""
         times = [


### PR DESCRIPTION
## Summary

Expands the glider QC notebook introduced in #94 to demonstrate additional
QARTOD tests on real Baltic Sea glider data (`nrt_SEA067_M37.nc`).

Closes #58

## Changes

- Added **Test 1 — Timing/Gap Test** using the newly implemented
  `timing_gap_test()` from PR #200. Demonstrates flagging of surface
  communication gaps between glider dives.
- Added **Test 7 — Spike Test** for temperature and salinity
- Added **Test 8 — Rate of Change Test** for temperature and salinity
- Added **Test 9 — Flat Line Test** for temperature and salinity
- Expanded QARTOD config with glider-specific thresholds for the Baltic
  Sea, following QARTOD Glider Manual (Table 3)
- Added inline notes explaining threshold choices and expected false
  positives in hydrographically uniform Baltic deep water
- Fixed `ds.dims` → `ds.sizes` to resolve xarray FutureWarning

## Results on `nrt_SEA067_M37.nc`

| Flag | Count | % | Notes |
|------|-------|---|-------|
| GOOD | 7198 | 93.2% | Clean in-water observations |
| SUSPECT | 439 | 5.7% | Uniform deep layers (flat line) + surface spikes |
| FAIL | 85 | 1.1% | Known near-surface outliers (sal ≈ 0, 1.5, 4.3 PSU) |

Timing/gap test separately identifies 107 observations following
inter-dive surface gaps > 1 hour.

## Related

- Expands: #94
- New function: #200
- Addresses: #58
