### PR TITLE
cleanup: remove dead code isnan(zinp.any())

### DIFF
--- a/ioos_qc/qartod.py
+++ b/ioos_qc/qartod.py
@@ -407,8 +407,7 @@ class ClimatologyConfig:
                 tinp_copy = tinp
 
             # If a zspan is defined but we don't have z input (zinp), skip this member
-            # Note: `zinp.count()` can return `np.ma.masked` so we also check using isnan
-            if not isnan(m.zspan) and (not zinp.count() or isnan(zinp.any())):
+            if not isnan(m.zspan) and not zinp.count():
                 continue
 
             # Indexes that align with the T


### PR DESCRIPTION
## Fixes issue #204 
## Summary
Follow-up cleanup after #107 and #108.

## Fix
```python
if not isnan(m.zspan) and not zinp.count():
```

## Notes
- No behavior change expected
- Existing `QartodClimatologyMissingTest` covers correct behavior
- Misleading comment above the line also removed