### PR TITLE
fix: expression stack not cleared

### DIFF
--- a/ioos_qc/config_creator/fx_parser.py
+++ b/ioos_qc/config_creator/fx_parser.py
@@ -159,6 +159,7 @@ def evaluate_stack(s, stats):
 
 def eval_fx(fx, stats):
     """Given fx and stats ('min', 'max', 'mean', 'std') return the result"""
+    exprStack.clear()
     _ = BNF().parse_string(fx, parse_all=True)
     val = evaluate_stack(exprStack[:], stats)
 


### PR DESCRIPTION
The expression stack was never getting cleared between calls, causing old tokens to pile up each time `eval_fx` was called.