### PR TITLE
Adjust period log message

### DIFF
--- a/ioos_qc/qartod.py
+++ b/ioos_qc/qartod.py
@@ -364,7 +364,7 @@ class ClimatologyConfig:
             try:
                 getattr(pd.Timestamp.now(), period)
             except AttributeError as err:
-                msg = 'The period "{period}" is not recognized'
+                msg = f'The period "{period}" is not recognized'
                 raise ValueError(msg) from err
 
         self._members.append(


### PR DESCRIPTION
Small contribution to improve the log message by correctly displaying the period value in the error message.

Pull request submitted as part of the 2026 GSoC work on the QARTOD toolbox.



