### PR TITLE
Rem py310

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [ "3.10", "3.14" ]
+        python-version: [ "3.11", "3.14" ]
         os: [ windows-latest, ubuntu-latest, macos-latest ]
         numba: [true, false]
       fail-fast: false

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -73,7 +73,7 @@ master_doc = "index"
 # General information about the project.
 import datetime
 
-year = datetime.datetime.now(tz=datetime.timezone.utc).date().year
+year = datetime.datetime.now(tz=datetime.UTC).date().year
 project = "ioos_qc"
 copyright = f"2022-{year}, IOOS"
 author = "IOOS"

--- a/ioos_qc/config_creator/config_creator.py
+++ b/ioos_qc/config_creator/config_creator.py
@@ -236,7 +236,7 @@ class QcVariableConfig(dict):
         for token in tokens:
             try:
                 _ = float(token)
-            except ValueError as err:  # noqa: PERF203
+            except ValueError as err:
                 if token not in self.allowed_stats and token not in self.allowed_operators and token not in self.allowed_groupings:
                     msg = (
                         f"{token} not allowed in min/max specification in config of {test_name}.\n"
@@ -439,11 +439,11 @@ class QcConfigCreator:
         start_time = datetime.datetime.strptime(
             variable_config["start_time"],
             "%Y-%m-%d",
-        ).replace(tzinfo=datetime.timezone.utc)
+        ).replace(tzinfo=datetime.UTC)
         end_time = datetime.datetime.strptime(
             variable_config["end_time"],
             "%Y-%m-%d",
-        ).replace(tzinfo=datetime.timezone.utc)
+        ).replace(tzinfo=datetime.UTC)
         time_range = slice(start_time, end_time)
         subset = self._get_subset(
             variable_config["variable"],

--- a/ioos_qc/qartod.py
+++ b/ioos_qc/qartod.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+# Standard library utilities
 import logging
 import warnings
 from collections import namedtuple
@@ -11,14 +12,17 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
     from numbers import Real
 
+# Scientific Python
 import numpy as np
 import pandas as pd
 
+# Numba for window_func speed
 try:
     from numba.core.errors import NumbaTypeError
 except ImportError:
     NumbaTypeError = TypeError
 
+# Internal ioos_qc helper utilities
 from ioos_qc.utils import (
     add_flag_metadata,
     great_circle_distance,

--- a/ioos_qc/qartod.py
+++ b/ioos_qc/qartod.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-# Standard library utilities
 import logging
 import warnings
 from collections import namedtuple
@@ -12,17 +11,14 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
     from numbers import Real
 
-# Scientific Python
 import numpy as np
 import pandas as pd
 
-# Numba for window_func speed
 try:
     from numba.core.errors import NumbaTypeError
 except ImportError:
     NumbaTypeError = TypeError
 
-# Internal ioos_qc helper utilities
 from ioos_qc.utils import (
     add_flag_metadata,
     great_circle_distance,

--- a/ioos_qc/utils.py
+++ b/ioos_qc/utils.py
@@ -129,7 +129,7 @@ def load_config_as_dict(
         for lf in load_funcs:
             try:
                 return lf(source)
-            except BaseException:  # noqa: S112, PERF203, BLE001
+            except BaseException:  # noqa: S112, BLE001
                 continue
 
     elif isinstance(source, io.StringIO):
@@ -141,7 +141,7 @@ def load_config_as_dict(
         for lf in load_funcs:
             try:
                 return lf(source.getvalue())
-            except BaseException:  # noqa: S112, PERF203, BLE001
+            except BaseException:  # noqa: S112, BLE001
                 continue
 
     msg = "Config source is not valid!"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,10 +15,9 @@ maintainers = [
   { name = "Filipe Fernandes", email = "ocefpaf+ioos_qc@gmail.com" },
   { name = "Kyle Wilcox", email = "kyle@axds.co" },
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 classifiers = [
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -19,7 +19,7 @@ if packaging.version.parse(
 ) < packaging.version.parse(
     "3.11",
 ):
-    datetime.UTC = datetime.timezone.utc
+    datetime.UTC = datetime.UTC
 
 
 class StreamConfigLoadTest(unittest.TestCase):

--- a/tests/test_config_creator.py
+++ b/tests/test_config_creator.py
@@ -24,7 +24,7 @@ if packaging.version.parse(
 ) < packaging.version.parse(
     "3.11",
 ):
-    datetime.UTC = datetime.timezone.utc
+    datetime.UTC = datetime.UTC
 
 
 class TestCreatorConfig(unittest.TestCase):


### PR DESCRIPTION
Removes the Python 3.10 statement from `pyproject.toml`, responsible for breaking current git workflows.

My previous changes were on `main` of my fork. Reverting 83d27cf5167691fbaa93221a7fe86a2eb8702221.