### PR TITLE
Fix numpy no units deprecation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
     - id: add-trailing-comma
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.15.15
+  rev: v0.15.19
   hooks:
     - id: ruff
       args: ["--fix", "--show-fixes"]
@@ -30,7 +30,7 @@ repos:
     - id: nb-strip-paths
 
 - repo: https://github.com/tox-dev/pyproject-fmt
-  rev: v2.23.0
+  rev: v2.25.0
   hooks:
     - id: pyproject-fmt
 
@@ -46,7 +46,7 @@ repos:
         - --ignore-words-list=pres,ba,ot
 
 - repo: https://github.com/woodruffw/zizmor-pre-commit
-  rev: v1.25.2
+  rev: v1.26.1
   hooks:
     - id: zizmor
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,6 @@
 [build-system]
 build-backend = "setuptools.build_meta"
-requires = [
-  "setuptools>=42",
-  "setuptools-scm",
-  "wheel",
-]
+requires = [ "setuptools>=42", "setuptools-scm" ]
 
 [project]
 name = "ioos-qc"

--- a/tests/test_axds.py
+++ b/tests/test_axds.py
@@ -29,8 +29,8 @@ class AxdsValidTimeBoundsTest(unittest.TestCase):
     def test_no_bounds(self):
         valid_spans = [
             (
-                np.datetime64("NaT"),
-                np.datetime64("NaT"),
+                np.datetime64("NaT", "ns"),
+                np.datetime64("NaT", "ns"),
             ),
             (
                 None,
@@ -51,7 +51,7 @@ class AxdsValidTimeBoundsTest(unittest.TestCase):
         valid_spans = [
             (
                 np.datetime64("2015-01-01T02:00:00"),
-                np.datetime64("NaT"),
+                np.datetime64("NaT", "ns"),
             ),
             (
                 np.datetime64("2015-01-01T02:00:00").astype(datetime),
@@ -71,7 +71,7 @@ class AxdsValidTimeBoundsTest(unittest.TestCase):
     def test_chop_end(self):
         valid_spans = [
             (
-                np.datetime64("NaT"),
+                np.datetime64("NaT", "ns"),
                 np.datetime64("2015-01-01T04:00:00"),
             ),
             (
@@ -133,7 +133,7 @@ class AxdsValidTimeBoundsTest(unittest.TestCase):
 
     def test_empty_chop_ends(self):
         valid_span = (
-            np.datetime64("NaT"),
+            np.datetime64("NaT", "ns"),
             np.datetime64("2015-01-01T04:00:00"),
         )
 
@@ -143,7 +143,7 @@ class AxdsValidTimeBoundsTest(unittest.TestCase):
             step=np.timedelta64(1, "h"),
             dtype=np.datetime64,
         )
-        times[0:2] = np.datetime64("NaT")
+        times[0:2] = np.datetime64("NaT", "ns")
 
         npt.assert_array_equal(
             axds.valid_range_test(
@@ -155,8 +155,8 @@ class AxdsValidTimeBoundsTest(unittest.TestCase):
 
     def test_all_empty(self):
         valid_span = (
-            np.datetime64("NaT"),
-            np.datetime64("NaT"),
+            np.datetime64("NaT", "ns"),
+            np.datetime64("NaT", "ns"),
         )
 
         times = np.arange(
@@ -165,7 +165,7 @@ class AxdsValidTimeBoundsTest(unittest.TestCase):
             step=np.timedelta64(1, "h"),
             dtype=np.datetime64,
         )
-        times[:] = np.datetime64("NaT")
+        times[:] = np.datetime64("NaT", "ns")
 
         npt.assert_array_equal(
             axds.valid_range_test(


### PR DESCRIPTION
It feels odd to add units to a NaT but this will fail in latest numpy without this fix.