### PR TITLE
Fix attenuated_signal_test std ddof mismatch between windowed and unwindowed paths

### DIFF
--- a/ioos_qc/qartod.py
+++ b/ioos_qc/qartod.py
@@ -859,7 +859,7 @@ def attenuated_signal_test(  # noqa: PLR0913
     # check_func: Applied to a flattened numpy array when no `time_period` is supplied
     # These are split for performance reasons
     if check_type == "std":
-        window_func = lambda x: x.std()  # noqa: E731
+        window_func = lambda x: x.std(ddof=0)  # noqa: E731  (match np.ma.std population SD)
         check_func = np.ma.std
     elif check_type == "range":
 

--- a/tests/test_qartod.py
+++ b/tests/test_qartod.py
@@ -1727,6 +1727,44 @@ class QartodAttenuatedSignalTest(unittest.TestCase):
             expected=expected,
         )
 
+    def test_attenuated_signal_std_windowed_matches_unwindowed(self):
+        # The windowed (test_period) and unwindowed "std" paths must agree once
+        # the windowed path has seen the same data as the unwindowed path (the
+        # whole series). A threshold strictly between the population std
+        # (ddof=0, ~1.1180) and the sample std (ddof=1, ~1.2910) of [1, 2, 3, 4]
+        # used to flag SUSPECT unwindowed but PASS windowed once the rolling
+        # window covered the full series, purely because of a ddof mismatch
+        # between np.ma.std (unwindowed) and pandas .std() (windowed).
+        signal = np.array([1, 2, 3, 4])
+        times = np.array(
+            [np.datetime64("2019-01-01") + np.timedelta64(i, "D") for i in range(signal.size)],
+        )
+
+        # Unwindowed: always computed over the whole series.
+        self._run_test(
+            times=times,
+            signal=signal,
+            suspect_threshold=1.2,
+            fail_threshold=0.5,
+            check_type="std",
+            expected=np.array([3, 3, 3, 3]),
+        )
+
+        # Windowed over a period covering the entire series, requiring all 4
+        # observations before computing (min_obs=4) so the windowed path only
+        # evaluates once it has the same data as the unwindowed path above.
+        # The last point must therefore match the unwindowed result (3).
+        self._run_test(
+            times=times,
+            signal=signal,
+            suspect_threshold=1.2,
+            fail_threshold=0.5,
+            check_type="std",
+            expected=np.array([2, 2, 2, 3]),
+            test_period=100 * 86400,
+            min_obs=4,
+        )
+
     def test_attenuated_signal_range(self):
         # range less than fail threshold
         signal = np.array([10, 20, 30, 40])


### PR DESCRIPTION
`attenuated_signal_test(check_type="std")` is supposed to compare a single "SD" against `MIN_VAR_FAIL`/`MIN_VAR_WARN`, per the manual (see below), but it actually computes two different standard deviations depending on whether you pass `test_period`:

```python
if check_type == "std":
    window_func = lambda x: x.std()  # noqa: E731   <- pandas Series.std, ddof=1 (sample)
    check_func = np.ma.std                          # <- numpy, ddof=0 (population)
```

`window_func` runs when `test_period` is given (rolling window), `check_func` runs when it isn't (whole series at once). The comment right above this split says it's split "for performance reasons," not to compute two different statistics, so I think the ddof mismatch is just an oversight from when these two paths were separated rather than something intentional.

**Why it matters:** identical data with identical thresholds can flag `SUSPECT` with one call and `PASS` with another, purely because of whether `test_period` was passed in - not because the data changed. For `[1, 2, 3, 4]`, population SD (ddof=0) is ~1.118 and sample SD (ddof=1) is ~1.291; a `suspect_threshold` of 1.2 sits between them, so the same series is `SUSPECT` unwindowed and `PASS` windowed over the whole series.

I checked this against two real series too, not just the synthetic case: the repo's own bundled `tests/data/20363_1000427.csv.gz` fixture, and a fresh pull of NDBC station 46050 (Stonewall Bank, OR) wave height data. Both show the same flip when the threshold falls between the two SDs of the window.

Reference: *Manual for Real-Time Quality Control of In-Situ Temperature and Salinity Data*, v2.0 Update 2 (March 2020), Test 10 "Attenuated Signal Test", p.21 - it defines one SD compared against the two thresholds, not two different SDs.

**Fix:** align `window_func` to `ddof=0` so it matches `np.ma.std`'s population SD (the one the unwindowed path already used).

**Test:** added `test_attenuated_signal_std_windowed_matches_unwindowed`, using `min_obs=4` so the windowed path only evaluates once it has the same full-series data the unwindowed path always uses. Without the fix it mismatches at the last point (`1` vs `3`); with the fix it matches (`3` vs `3`). I confirmed this by stashing the source fix and re-running just to make sure the test actually fails the way I expect:

```
Mismatch at index:
 [3]: 1 (ACTUAL), 3 (DESIRED)
```

and passes clean after unstashing it back.

Full `test_qartod.py` suite: 69/69 pass with the fix. The only other failures in the full test tree are pre-existing and unrelated (`test_config_creator.py` needs local NARR/Ocean Atlas assets via `get_assets.py`, `test_utils.py` needs the optional `h5py` backend) - neither touches `qartod.py`.

Happy to adjust the fix direction if you'd rather standardize on `ddof=1` in both paths instead - the important part is that both paths compute the same SD.

(Used Claude Code to help verify this against the manual and real data before opening the PR - wanted to flag that up front.)
