### PR TITLE
Use ddof=0 for standard deviation calculations

### DIFF
--- a/ioos_qc/config_creator/config_creator.py
+++ b/ioos_qc/config_creator/config_creator.py
@@ -455,7 +455,7 @@ class QcConfigCreator:
             "min": np.nanmin(subset),
             "max": np.nanmax(subset),
             "mean": np.nanmean(subset),
-            "std": np.nanstd(subset),
+            "std": np.nanstd(subset, ddof=0),
         }
 
     def _get_subset(self, var, bbox, time_slice, depth=0, pad_delta=0.5):

--- a/ioos_qc/qartod.py
+++ b/ioos_qc/qartod.py
@@ -859,7 +859,7 @@ def attenuated_signal_test(  # noqa: PLR0913
     # check_func: Applied to a flattened numpy array when no `time_period` is supplied
     # These are split for performance reasons
     if check_type == "std":
-        window_func = lambda x: x.std()  # noqa: E731
+        window_func = lambda x: x.std(ddof=0)  # noqa: E731
         check_func = np.ma.std
     elif check_type == "range":
 


### PR DESCRIPTION
Make the standard deviation calculation explicit and consistent by specifying `ddof=0` in `qartod.py` and `config_creator.py`. This change does not modify the current behavior, since `ddof=0` is already the default. It simply makes the intended degrees of freedom consistent across the package.