### PR TITLE
Range

### DIFF
--- a/ioos_qc/qartod.py
+++ b/ioos_qc/qartod.py
@@ -198,7 +198,7 @@ def gross_range_test(
 
     Given a 2-tuple of minimum/maximum values, flag data outside of the given
     range as FAIL data.  Optionally also flag data which falls outside of a user
-    defined range as SUSPECT. Missing and masked data is flagged as UNKNOWN.
+    defined range as SUSPECT. Missing and masked data is flagged as MISSING.
 
     Parameters
     ----------

--- a/ioos_qc/qartod.py
+++ b/ioos_qc/qartod.py
@@ -265,15 +265,16 @@ def gross_range_test(
 
     return flag_arr.reshape(original_shape)
 
+
 @add_flag_metadata(
     standard_name="percentile_range_test_quality_flag",
     long_name="Percentile Range Test Quality Flag",
 )
 def percentile_range_test(
-        inp: Sequence[Real],
-        low_percentile: Real=5,
-        hi_percentile: Real=95,
-        pad: Real=0.0
+    inp: Sequence[Real],
+    low_percentile: Real = 5,
+    hi_percentile: Real = 95,
+    pad: Real = 0.0,
 ) -> np.ma.core.MaskedArray:
     """Checks for statistically abnormal values in the array.
 
@@ -282,13 +283,13 @@ def percentile_range_test(
     for the data if not user-defined. In addition, the user may specify a padding
     value for additional coverage.
 
-    If the point's (value < low_percentile_value - pad) or 
+    If the point's (value < low_percentile_value - pad) or
     (high_percentile value + pad < value) then the point is flagged as SUSPECT.
     Points within the data which are NaN are flagged as MISSING. Otherwise, points
     are flagged as PASS.
 
-    Parameters:
-    -----------
+    Parameters
+    ----------
     inp
         Input array as a numeric numpy array or list of real numbers.
     low_percentile
@@ -298,12 +299,12 @@ def percentile_range_test(
     pad
         A user-defined, numeric padding value for adding atop the hi/low percentile
         values. Defaults to 0 (optional).
-    
+
     Returns
     -------
     flag_arr
         A masked array of flag values equal in size to that of the input `inp`.
-    
+
     Examples
     --------
     Say we have some values that we are expecting to be clusered around a specific
@@ -317,9 +318,10 @@ def percentile_range_test(
              mask=False,
        fill_value=np.uint64(999999),
             dtype=uint8)
-    
+
     This has flagged the statistically lowest and highest value as SUSPECT with no
     padding specified.
+
     """
     original_shape = inp.shape
     inp = np.ma.asarray(inp, dtype=float).flatten()

--- a/ioos_qc/qartod.py
+++ b/ioos_qc/qartod.py
@@ -229,19 +229,12 @@ def gross_range_test(
 
     #   Helper function to guarantee contents of inputs are good
     #   Sort the span
-    def check_span(name: str, arr: Sequence[Real]) -> span:
-        if not isfixedlength(arr, 2):
-            msg = f"{name}={arr!r}, expected a length-2 sequence"
-            raise ValueError(msg)
-
-        if not all(isinstance(v, Real) for v in arr):
-            msg = f"{name} must contain only numeric values"
-            raise TypeError(msg)
-
+    def check_span(arr: Sequence[Real]) -> span:
+        isfixedlength(arr, 2)
         return span(*sorted(arr))
 
     #   Fail or "sensor" span
-    sspan = check_span(name="fail_span", arr=fail_span)
+    sspan = check_span(arr=fail_span)
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
@@ -258,7 +251,7 @@ def gross_range_test(
 
     if suspect_span is not None:
         #   Suspect or "user" span
-        uspan = check_span(name="suspect_span", arr=suspect_span)
+        uspan = check_span(arr=suspect_span)
         if uspan.minv < sspan.minv or uspan.maxv > sspan.maxv:
             msg = f"Suspect {uspan} must fall within the Fail {sspan}"
             raise ValueError(msg)
@@ -270,6 +263,77 @@ def gross_range_test(
     with np.errstate(invalid="ignore"):
         flag_arr[(inp < sspan.minv) | (inp > sspan.maxv)] = QartodFlags.FAIL
 
+    return flag_arr.reshape(original_shape)
+
+@add_flag_metadata(
+    standard_name="percentile_range_test_quality_flag",
+    long_name="Percentile Range Test Quality Flag",
+)
+def percentile_range_test(
+        inp: Sequence[Real],
+        low_percentile: Real=5,
+        hi_percentile: Real=95,
+        pad: Real=0.0
+) -> np.ma.core.MaskedArray:
+    """Checks for statistically abnormal values in the array.
+
+    Given an array of numeric values, this test identifies abnormal high and low
+    values at statistical percentiles. These default to the 5th and 95th percentiles
+    for the data if not user-defined. In addition, the user may specify a padding
+    value for additional coverage.
+
+    If the point's (value < low_percentile_value - pad) or 
+    (high_percentile value + pad < value) then the point is flagged as SUSPECT.
+    Points within the data which are NaN are flagged as MISSING. Otherwise, points
+    are flagged as PASS.
+
+    Parameters:
+    -----------
+    inp
+        Input array as a numeric numpy array or list of real numbers.
+    low_percentile
+        A user-defined low-percentile numeric bound, defaults to 5 (optional).
+    hi_percentile
+        A user-defined high-percentile numeric bound, defaults to 95 (optional).
+    pad
+        A user-defined, numeric padding value for adding atop the hi/low percentile
+        values. Defaults to 0 (optional).
+    
+    Returns
+    -------
+    flag_arr
+        A masked array of flag values equal in size to that of the input `inp`.
+    
+    Examples
+    --------
+    Say we have some values that we are expecting to be clusered around a specific
+    range and we want to flag potential outliers that exceed the largest values
+    in the data array including a little wiggle room.
+
+    >>> data = np.array([4.1, 4.0, 4.3, 4.5, 6.1, 6.2])
+    >>> flags = percentile_range_test(data)
+    >>> flags
+    masked_array(data=[1, 3, 1, 1, 1, 3],
+             mask=False,
+       fill_value=np.uint64(999999),
+            dtype=uint8)
+    
+    This has flagged the statistically lowest and highest value as SUSPECT with no
+    padding specified.
+    """
+    original_shape = inp.shape
+    inp = np.ma.asarray(inp, dtype=float).flatten()
+    flag_arr = np.ma.ones(inp.size, dtype="uint8")
+
+    inp.mask = np.isnan(inp.data)
+    flag_arr[inp.mask] = QartodFlags.MISSING
+    valid = ~inp.mask
+
+    low, hi = np.percentile(inp.data[valid], [low_percentile, hi_percentile])
+    bound_low = low - pad
+    bound_hi = hi + pad
+
+    flag_arr[(inp < bound_low) | (inp > bound_hi)] = QartodFlags.SUSPECT
     return flag_arr.reshape(original_shape)
 
 

--- a/ioos_qc/qartod.py
+++ b/ioos_qc/qartod.py
@@ -214,11 +214,34 @@ def gross_range_test(
     flag_arr
         A masked array of flag values equal in size to that of the input.
 
+    Examples
+    --------
+    Note that any input `inp` should be a sequence of numerical values that can be converted to numpy.
+
+    >>> flags = gross_range_test(inp=[1, 2, 3, 4, 8], fail_span=(0, 5), suspect_span=(1, 4))
+    >>> flags
+    masked_array(data=[1, 1, 1, 1, 4],
+                mask=False,
+        fill_value=np.uint64(999999),
+                dtype=uint8)
+
     """
-    if not isfixedlength(fail_span, 2):
-        msg = f"{fail_span=}, expected 2"
-        raise ValueError(msg)
-    sspan = span(*sorted(fail_span))
+
+    #   Helper function to guarantee contents of inputs are good
+    #   Sort the span
+    def check_span(name: str, arr: Sequence[Real]) -> span:
+        if not isfixedlength(arr, 2):
+            msg = f"{name}={arr!r}, expected a length-2 sequence"
+            raise ValueError(msg)
+
+        if not all(isinstance(v, Real) for v in arr):
+            msg = f"{name} must contain only numeric values"
+            raise TypeError(msg)
+
+        return span(*sorted(arr))
+
+    #   Fail or "sensor" span
+    sspan = check_span(name="fail_span", arr=fail_span)
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
@@ -234,10 +257,8 @@ def gross_range_test(
     flag_arr[inp.mask] = QartodFlags.MISSING
 
     if suspect_span is not None:
-        if not isfixedlength(suspect_span, 2):
-            msg = f"{suspect_span=}, expected 2."
-            raise ValueError(msg)
-        uspan = span(*sorted(suspect_span))
+        #   Suspect or "user" span
+        uspan = check_span(name="suspect_span", arr=suspect_span)
         if uspan.minv < sspan.minv or uspan.maxv > sspan.maxv:
             msg = f"Suspect {uspan} must fall within the Fail {sspan}"
             raise ValueError(msg)

--- a/tests/test_qartod.py
+++ b/tests/test_qartod.py
@@ -8,7 +8,6 @@ import pandas as pd
 import pytest
 
 from ioos_qc import qartod
-from numbers import Real
 
 L = logging.getLogger("ioos_qc")
 L.setLevel(logging.INFO)
@@ -284,39 +283,53 @@ class QartodGrossRangeTest(unittest.TestCase):
 #   For use in percentile_range_test
 #   Min value is 4.0 (ix=1), max is 6.2 (5)
 PERCENTILE_ARR = np.array(
-    [4.1, 4.0, 4.3, 4.5, 6.1,
-     6.2, 4.3, 4.6, 4.5, 4.4]
+    [
+        4.1,
+        4.0,
+        4.3,
+        4.5,
+        6.1,
+        6.2,
+        4.3,
+        4.6,
+        4.5,
+        4.4,
+    ],
 )
 
 
 @pytest.mark.parametrize(
     ("data", "lo", "hi", "pad", "expected"),
     [
-        (PERCENTILE_ARR,5,95,0.0,[1,3,1,1,1,3,1,1,1,1]), # Test the default padding
-        (PERCENTILE_ARR,5,95,0.1,[1,1,1,1,1,1,1,1,1,1]),
-        (PERCENTILE_ARR,20,95,0.1,[3,3,1,1,1,1,1,1,1,1]),
-        (PERCENTILE_ARR,20,95,0.5,[1,1,1,1,1,1,1,1,1,1]),
-        (PERCENTILE_ARR,5,80,0.0,[1,3,1,1,3,3,1,1,1,1]),
-        (PERCENTILE_ARR,5,80,0.1,[1,1,1,1,3,3,1,1,1,1]),
+        (PERCENTILE_ARR, 5, 95, 0.0, [1, 3, 1, 1, 1, 3, 1, 1, 1, 1]),  # Test the default padding
+        (PERCENTILE_ARR, 5, 95, 0.1, [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]),
+        (PERCENTILE_ARR, 20, 95, 0.1, [3, 3, 1, 1, 1, 1, 1, 1, 1, 1]),
+        (PERCENTILE_ARR, 20, 95, 0.5, [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]),
+        (PERCENTILE_ARR, 5, 80, 0.0, [1, 3, 1, 1, 3, 3, 1, 1, 1, 1]),
+        (PERCENTILE_ARR, 5, 80, 0.1, [1, 1, 1, 1, 3, 3, 1, 1, 1, 1]),
     ],
 )
 def test_percentile_range_good(data, hi, lo, pad, expected):
     flags = qartod.percentile_range_test(
-        data, low_percentile=lo, hi_percentile=hi, pad=pad
+        data,
+        low_percentile=lo,
+        hi_percentile=hi,
+        pad=pad,
     )
-    # breakpoint()
     npt.assert_array_equal(
-        flags.data, expected
+        flags.data,
+        expected,
     )
 
+
 def test_percentile_range_err():
-    "Break the function in as many expected ways as possible"
+    """Break the function in as many expected ways as possible."""
     with pytest.raises(TypeError, match=r"'NoneType' and 'int'"):
         qartod.percentile_range_test(PERCENTILE_ARR, low_percentile=None)
 
     with pytest.raises(TypeError, match=r"'float' and 'NoneType'"):
-            qartod.percentile_range_test(PERCENTILE_ARR, pad=None)
-    
+        qartod.percentile_range_test(PERCENTILE_ARR, pad=None)
+
 
 def test_percentile_range_names():
     assert qartod.percentile_range_test.long_name == "Percentile Range Test Quality Flag"

--- a/tests/test_qartod.py
+++ b/tests/test_qartod.py
@@ -301,21 +301,28 @@ PERCENTILE_ARR = np.array(
 @pytest.mark.parametrize(
     ("data", "lo", "hi", "pad", "expected"),
     [
-        (PERCENTILE_ARR, 5, 95, 0.0, [1, 3, 1, 1, 1, 3, 1, 1, 1, 1]),  # Test the default padding
-        (PERCENTILE_ARR, 5, 95, 0.1, [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]),
-        (PERCENTILE_ARR, 20, 95, 0.1, [3, 3, 1, 1, 1, 1, 1, 1, 1, 1]),
-        (PERCENTILE_ARR, 20, 95, 0.5, [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]),
-        (PERCENTILE_ARR, 5, 80, 0.0, [1, 3, 1, 1, 3, 3, 1, 1, 1, 1]),
-        (PERCENTILE_ARR, 5, 80, 0.1, [1, 1, 1, 1, 3, 3, 1, 1, 1, 1]),
+        (PERCENTILE_ARR, None, None, None, [1, 3, 1, 1, 1, 3, 1, 1, 1, 1]),  # Test the default padding
+        (PERCENTILE_ARR, None, None, 0.1, [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]),
+        (PERCENTILE_ARR, 20, None, 0.1, [3, 3, 1, 1, 1, 1, 1, 1, 1, 1]),
+        (PERCENTILE_ARR, 20, None, 0.5, [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]),
+        (PERCENTILE_ARR, None, 80, None, [1, 3, 1, 1, 3, 3, 1, 1, 1, 1]),
+        (PERCENTILE_ARR, None, 80, 0.1, [1, 1, 1, 1, 3, 3, 1, 1, 1, 1]),
     ],
 )
 def test_percentile_range_good(data, hi, lo, pad, expected):
-    flags = qartod.percentile_range_test(
-        data,
-        low_percentile=lo,
-        hi_percentile=hi,
-        pad=pad,
-    )
+
+    #   Add support for None in the parametrized values such that it's easier to see what values
+    #   eahc combo tests
+    kwargs = {}
+    if lo is not None:
+        kwargs["low_percentile"] = lo
+    if hi is not None:
+        kwargs["hi_percentile"] = hi
+    if pad is not None:
+        kwargs["pad"] = pad
+
+    flags = qartod.percentile_range_test(data, **kwargs)
+
     npt.assert_array_equal(
         flags.data,
         expected,

--- a/tests/test_qartod.py
+++ b/tests/test_qartod.py
@@ -312,7 +312,7 @@ PERCENTILE_ARR = np.array(
 def test_percentile_range_good(data, hi, lo, pad, expected):
 
     #   Add support for None in the parametrized values such that it's easier to see what values
-    #   eahc combo tests
+    #   each combo tests
     kwargs = {}
     if lo is not None:
         kwargs["low_percentile"] = lo

--- a/tests/test_qartod.py
+++ b/tests/test_qartod.py
@@ -8,6 +8,7 @@ import pandas as pd
 import pytest
 
 from ioos_qc import qartod
+from numbers import Real
 
 L = logging.getLogger("ioos_qc")
 L.setLevel(logging.INFO)
@@ -278,6 +279,48 @@ class QartodGrossRangeTest(unittest.TestCase):
                 ),
                 result,
             )
+
+
+#   For use in percentile_range_test
+#   Min value is 4.0 (ix=1), max is 6.2 (5)
+PERCENTILE_ARR = np.array(
+    [4.1, 4.0, 4.3, 4.5, 6.1,
+     6.2, 4.3, 4.6, 4.5, 4.4]
+)
+
+
+@pytest.mark.parametrize(
+    ("data", "lo", "hi", "pad", "expected"),
+    [
+        (PERCENTILE_ARR,5,95,0.0,[1,3,1,1,1,3,1,1,1,1]), # Test the default padding
+        (PERCENTILE_ARR,5,95,0.1,[1,1,1,1,1,1,1,1,1,1]),
+        (PERCENTILE_ARR,20,95,0.1,[3,3,1,1,1,1,1,1,1,1]),
+        (PERCENTILE_ARR,20,95,0.5,[1,1,1,1,1,1,1,1,1,1]),
+        (PERCENTILE_ARR,5,80,0.0,[1,3,1,1,3,3,1,1,1,1]),
+        (PERCENTILE_ARR,5,80,0.1,[1,1,1,1,3,3,1,1,1,1]),
+    ],
+)
+def test_percentile_range_good(data, hi, lo, pad, expected):
+    flags = qartod.percentile_range_test(
+        data, low_percentile=lo, hi_percentile=hi, pad=pad
+    )
+    # breakpoint()
+    npt.assert_array_equal(
+        flags.data, expected
+    )
+
+def test_percentile_range_err():
+    "Break the function in as many expected ways as possible"
+    with pytest.raises(TypeError, match=r"'NoneType' and 'int'"):
+        qartod.percentile_range_test(PERCENTILE_ARR, low_percentile=None)
+
+    with pytest.raises(TypeError, match=r"'float' and 'NoneType'"):
+            qartod.percentile_range_test(PERCENTILE_ARR, pad=None)
+    
+
+def test_percentile_range_names():
+    assert qartod.percentile_range_test.long_name == "Percentile Range Test Quality Flag"
+    assert qartod.percentile_range_test.standard_name == "percentile_range_test_quality_flag"
 
 
 class QartodClimatologyPeriodTest(unittest.TestCase):


### PR DESCRIPTION
Assesses the `gross_range_test` listed in the "required" tests of the [IOOS-QARTOD manual](https://cdn.ioos.noaa.gov/media/2017/12/Manual-for-QC-of-Glider-Data_05_09_16.pdf).

* Tweaks the docstring for `gross_range_test` to more accurately reflect returned flags.
* Simplifies `gross_range_test` with a helper function for sorting user spans
* Adds a new function, `percentile_range_test`
  * Flags statistically abnormal values in the array by percentile, give or take a user-defined `pad` value.
  * Useful in cases where the user does not know limits for `gross_range_test` or is looking for abnormal behavior.
* Modify unit tests in `test_qartod.py` to guarantee 100% coverage on both functions.

Further documentation, experimentation, and rationale is described in the [Deliverable 2 notebook](https://github.com/Klankers/mau_gsoc_qartod/blob/main/deliverable_2.ipynb).

Remaining tests for GSoC deliverable 2:
* `pressure`
* `density_inversion`
* `climatology`