### PR TITLE
Remove dead isnan(zinp.any()) check in ClimatologyConfig.check

### DIFF
--- a/ioos_qc/qartod.py
+++ b/ioos_qc/qartod.py
@@ -610,8 +610,7 @@ class ClimatologyConfig:
                 tinp_copy = tinp
 
             # If a zspan is defined but we don't have z input (zinp), skip this member
-            # Note: `zinp.count()` can return `np.ma.masked` so we also check using isnan
-            if not isnan(m.zspan) and (not zinp.count() or isnan(zinp.any())):
+            if not isnan(m.zspan) and not zinp.count():
                 continue
 
             # Indexes that align with the T


### PR DESCRIPTION
`zinp.any()` returns `np.ma.masked` when every value is masked, and the `isnan` helper does count that as nan, but `zinp.count()` is 0 in exactly that case so the `or` short-circuits and the second term never changes the result. I removed it and the comment above it, which was wrong anyway since `count()` returns an int, not `np.ma.masked`. Climatology tests pass unchanged.

I used an AI assistant on this one.

Closes #204