### PR TITLE
add h5py dependency

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,6 @@
 bokeh
 erddapy
+h5py
 ipykernel
 matplotlib>=3
 nbsphinx
@@ -8,4 +9,3 @@ pooch
 pynco
 sphinx
 sphinx-autodoc-typehints
-h5py

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,3 +8,4 @@ pooch
 pynco
 sphinx
 sphinx-autodoc-typehints
+h5py


### PR DESCRIPTION
This PR adds the missing `h5py` dependency to the requirements, as mentioned in #237.