### PR TITLE
Pressure

### DIFF
--- a/ioos_qc/argo.py
+++ b/ioos_qc/argo.py
@@ -45,7 +45,7 @@ def pressure_increasing_test(inp: Sequence[N], direction: str = "auto", pres_rev
         sign of the change in pressure. Defaults to "auto".
     pres_reversal
         Float of the user-defined pressure reversal threshold, in dbar (optional).
-        Defaults to 20 dbar.
+        Defaults to 20 dbar (see quality control manual above).
 
     Returns
     -------
@@ -73,7 +73,7 @@ def pressure_increasing_test(inp: Sequence[N], direction: str = "auto", pres_rev
     v_0 = valid[0]
     if direction == "up":
         min_p = inp[v_0]
-        for i in valid[:1]:
+        for i in valid[1:]:
             if inp[i] >= min_p + pres_reversal:
                 flag_arr[i] = QartodFlags.FAIL
             min_p = min(min_p, inp[i])

--- a/ioos_qc/argo.py
+++ b/ioos_qc/argo.py
@@ -17,35 +17,77 @@ L = logging.getLogger(__name__)
     standard_name="pressure_increasing_test_quality_flag",
     long_name="Pressure Increasing Test Quality Flag",
 )
-def pressure_increasing_test(inp):
-    """Returns an array of flag values where each input is flagged with SUSPECT if
-    it does not monotonically increase.
+def pressure_increasing_test(inp: Sequence[N], direction: str = "auto", pres_reversal: float = 20):
+    """Checks for monotonic series of pressure values with user-defined reversal threshold.
 
-    Ref: ARGO QC Manual: 8. Pressure increasing test
+    This differs from qartod.pressure_test, as it keeps a running log of all previous
+    pressure values and compares the min/max against it.
+
+    Flags that fail this test are returned as FAIL, otherwise they are returned as PASS.
+    Data points that are missing for calculations are returned as MISSING.
+
+    'For near-surface profiles, this test should be run from the deepest pressure
+    to the shallowest pressure. For all other profiles, this test should be run from the
+    middle of the profile to the shallowest pressure, and from the middle of the profile
+    to the deepest pressure. The middle of the profile is the pressure at
+    length(profile)/2'
+
+    See Wong et al. 2025 (Argo quality control manual v3.9):
+        http://dx.doi.org/10.13155/33951
 
     Parameters
     ----------
     inp
-        Pressure values as a numeric numpy array or a list of numbers.
-
+        Sequence of real numbers for the input pressure array, in units of dbar.
+    direction
+        String of AUV direction "up" or "down". "up" indicates going from deep to shallow,
+        or the upcast (optional). For old functionality, select "auto" to estimate the
+        sign of the change in pressure. Defaults to "auto".
+    pres_reversal
+        Float of the user-defined pressure reversal threshold, in dbar (optional).
+        Defaults to 20 dbar.
+    
     Returns
     -------
     flag_arr
         A masked array of flag values equal in size to that of the input.
 
     """
-    delta = np.diff(inp)
-    flags = np.ones_like(inp, dtype="uint8") * QartodFlags.GOOD
+    inp = np.ma.asarray(inp, dtype=float)
+    inp.mask = np.isnan(inp.data)
 
-    # Correct for downcast vs upcast by flipping the sign if it's decreasing
-    sign = np.sign(np.mean(delta))
-    if sign < 0:
-        delta = sign * delta
+    flag_arr = np.ma.ones(inp.shape, dtype="uint8")
+    flag_arr[inp.mask] = QartodFlags.MISSING
+    valid = ~inp.mask
+    valid = np.flatnonzero(valid)
 
-    flag_idx = np.where(delta <= 0)[0] + 1
-    flags[flag_idx] = QartodFlags.SUSPECT
-
-    return flags
+    if direction == "auto":
+        #   Reassign the direction. If sign is positive, press is decreasing so say "down"
+        delta = np.diff(inp)
+        sign = np.sign(np.nanmean(delta))
+        if sign < 0:
+            direction = "up"
+        elif sign > 0:
+            direction = "down"
+    #   Need first valid non-NaN
+    v_0 = valid[0]
+    if direction == "up":
+        min_p = inp[v_0]
+        for i in valid[:1]:
+            if inp[i] >= min_p + pres_reversal:
+                flag_arr[i] = QartodFlags.FAIL
+            min_p = min(min_p, inp[i])
+    elif direction == "down":
+        max_p = inp[v_0]
+        for i in valid[1:]:
+            if inp[i] <= max_p - pres_reversal:
+                flag_arr[i] = QartodFlags.FAIL
+            max_p = max(max_p, inp[i])
+    else:
+        msg = f"'Direction' argument ({direction}) not within defined options for this test."
+        raise ValueError(msg)
+    
+    return flag_arr
 
 
 @add_flag_metadata(

--- a/ioos_qc/argo.py
+++ b/ioos_qc/argo.py
@@ -13,6 +13,30 @@ from ioos_qc.utils import add_flag_metadata, great_circle_distance, mapdates
 L = logging.getLogger(__name__)
 
 
+def _pressure_flag_by_direction(
+    inp: Sequence[N],
+    valid: Sequence[N],
+    flag_arr: Sequence[N],
+    pres_reversal: float,
+    direction: str,
+) -> None:
+    """Flagging logic for pressure_increasing_test based on direction."""
+    tracked_value = inp[valid[0]]
+    if direction == "up":
+        for i in valid[1:]:
+            if inp[i] >= tracked_value + pres_reversal:
+                flag_arr[i] = QartodFlags.FAIL
+            tracked_value = min(tracked_value, inp[i])
+    elif direction == "down":
+        for i in valid[1:]:
+            if inp[i] <= tracked_value - pres_reversal:
+                flag_arr[i] = QartodFlags.FAIL
+            tracked_value = max(tracked_value, inp[i])
+    else:
+        msg = f"'Direction' argument ({direction}) not within defined options for this test."
+        raise ValueError(msg)
+
+
 @add_flag_metadata(
     standard_name="pressure_increasing_test_quality_flag",
     long_name="Pressure Increasing Test Quality Flag",
@@ -69,23 +93,8 @@ def pressure_increasing_test(inp: Sequence[N], direction: str = "auto", pres_rev
             direction = "up"
         elif sign > 0:
             direction = "down"
-    #   Need first valid non-NaN
-    v_0 = valid[0]
-    if direction == "up":
-        min_p = inp[v_0]
-        for i in valid[1:]:
-            if inp[i] >= min_p + pres_reversal:
-                flag_arr[i] = QartodFlags.FAIL
-            min_p = min(min_p, inp[i])
-    elif direction == "down":
-        max_p = inp[v_0]
-        for i in valid[1:]:
-            if inp[i] <= max_p - pres_reversal:
-                flag_arr[i] = QartodFlags.FAIL
-            max_p = max(max_p, inp[i])
-    else:
-        msg = f"'Direction' argument ({direction}) not within defined options for this test."
-        raise ValueError(msg)
+
+    _pressure_flag_by_direction(inp, valid, flag_arr, pres_reversal, direction)
 
     return flag_arr
 

--- a/ioos_qc/argo.py
+++ b/ioos_qc/argo.py
@@ -46,7 +46,7 @@ def pressure_increasing_test(inp: Sequence[N], direction: str = "auto", pres_rev
     pres_reversal
         Float of the user-defined pressure reversal threshold, in dbar (optional).
         Defaults to 20 dbar.
-    
+
     Returns
     -------
     flag_arr
@@ -86,7 +86,7 @@ def pressure_increasing_test(inp: Sequence[N], direction: str = "auto", pres_rev
     else:
         msg = f"'Direction' argument ({direction}) not within defined options for this test."
         raise ValueError(msg)
-    
+
     return flag_arr
 
 

--- a/ioos_qc/qartod.py
+++ b/ioos_qc/qartod.py
@@ -1211,7 +1211,7 @@ def pressure_test(
     pad: float = 0.01,
     assess_floating: bool = False,
     breakout: float = 0.025,
-)-> np.ma.core.MaskedArray:
+) -> np.ma.core.MaskedArray:
     """Checks for for continuous monotonic sequences in the provided data.
 
     Intended for use on the pressure array, `inp`. The input array is differentiated
@@ -1244,7 +1244,7 @@ def pressure_test(
     breakout
         Float representing the required change in the `inp` variable to break
         the assess_floating routine (optional). Defaults to 0.025.
-    
+
     Returns
     -------
     flag_arr
@@ -1281,7 +1281,6 @@ def pressure_test(
     [3 3 3 1 9 1 1 3 1]
 
     """
-
     original_shape = inp.shape
     inp = np.ma.asarray(inp, dtype=float).flatten()
     flag_arr = np.ma.ones(inp.size, dtype="uint8")
@@ -1316,13 +1315,10 @@ def pressure_test(
                 if flag_arr[i] == QartodFlags.SUSPECT:
                     is_floating = True
                     floating_ix[i] = True
+            elif (direction == "down" and val >= breakout) or (direction == "up" and val <= -breakout):
+                is_floating = False
             else:
-                if direction == "down" and val >= breakout:
-                    is_floating = False
-                elif direction =="up" and val <= -breakout:
-                    is_floating = False
-                else:
-                    floating_ix[i] = True
+                floating_ix[i] = True
         flag_arr[valid & floating_ix] = QartodFlags.SUSPECT
 
     return flag_arr.reshape(original_shape)

--- a/ioos_qc/qartod.py
+++ b/ioos_qc/qartod.py
@@ -1268,7 +1268,7 @@ def pressure_test(
     [3 3 3 1 9 1 1 3 1]
 
     To look for a purely monotonic sequence, where pressure is simply
-    increaing/decreasing, remove the padding altogether by setting it to 0.
+    increasing/decreasing, remove the padding altogether by setting it to 0.
     >>> flags = pressure_test(arr, "down", pad=0.0)
     >>> print(flags)
     [1 1 1 1 9 1 1 3 1]

--- a/ioos_qc/qartod.py
+++ b/ioos_qc/qartod.py
@@ -1202,6 +1202,133 @@ def attenuated_signal_test(  # noqa: PLR0913, PLR0917
 
 
 @add_flag_metadata(
+    standard_name="pressure_test_quality_flag",
+    long_name="Pressure Test Quality Flag",
+)
+def pressure_test(
+    inp: Sequence[Real],
+    direction: str,
+    pad: float = 0.01,
+    assess_floating: bool = False,
+    breakout: float = 0.025,
+)-> np.ma.core.MaskedArray:
+    """Checks for for continuous monotonic sequences in the provided data.
+
+    Intended for use on the pressure array, `inp`. The input array is differentiated
+    and values that do not increase or decrease (specified in `direction`) by at least
+    the tolerance value `pad` are flagged as SUSPECT. Any NaNs found in the input are
+    flagged MISSING. Otherwise, values in the array are flagged as PASS.
+
+    If the input is relatively unchanging (i.e., neutral buoyancy, at rest), these
+    values should fall within the user-designated `pad` parameter. An optional test
+    can be performed by setting `assess_floating` to True, which uses `breakout` as
+    the designated 'breakout' requirement.
+
+    Input arrays should be for a single PROFILE_NUMBER, be it the "downglide" or
+    "upglide" (see the OG1.0 methodology documentation for more information:
+    https://oceangliderscommunity.github.io/OG-format-user-manual/OG_Format.html)
+
+    Parameters
+    ----------
+    inp
+        Data vector to be flagged, as an array-like sequence of real numbers.
+    direction
+        String that declares which direction the glider is going. Options of
+        "down" (pressure increasing), "up" (pressure decreasing)
+    pad
+        Float of "unmoving allowance". If `inp` changes by more than pad, it is
+        considered moving and flagging changes. Defaults to 0.01.
+    assess_floating
+        Bool, specifying whether to run an additional flagging routine (optional)
+        Defaults to False.
+    breakout
+        Float representing the required change in the `inp` variable to break
+        the assess_floating routine (optional). Defaults to 0.025.
+    
+    Returns
+    -------
+    flag_arr
+        A masked array of flag values equal in size to that of the input.
+
+    Examples
+    --------
+    >>> arr = np.array([1, 1.009, 1.02, 2, np.nan, 2.001, 7, 0, 2])
+    >>> print(np.diff(arr))
+    [ 0.009  0.011  0.98     nan    nan  4.999 -7.     2.   ]
+
+    When using the default pressure test settings (pad=0.1, float test is off)
+    we expect points to be flagged if they are not exceeding a pres. tolerance.
+    >>> flags = pressure_test(arr, "down")
+    >>> print(flags)
+    [3 3 1 1 9 1 1 3 1]
+
+    Meanwhile, a more strict padding will flag more points
+    >>> flags = pressure_test(arr, "down", pad=0.1)
+    >>> print(flags)
+    [3 3 3 1 9 1 1 3 1]
+
+    To look for a purely monotonic sequence, where pressure is simply
+    increaing/decreasing, remove the padding altogether by setting it to 0.
+    >>> flags = pressure_test(arr, "down", pad=0.0)
+    >>> print(flags)
+    [1 1 1 1 9 1 1 3 1]
+
+    An extra (optional) test can be performed to detect periods where the array
+    is floating or unchanging with a second, stricter tolerance. As per the first
+    example:
+    >>> flags = pressure_test(arr, "down", assess_floating=True)
+    >>> print(flags)
+    [3 3 3 1 9 1 1 3 1]
+
+    """
+
+    original_shape = inp.shape
+    inp = np.ma.asarray(inp, dtype=float).flatten()
+    flag_arr = np.ma.ones(inp.size, dtype="uint8")
+
+    inp.mask = np.isnan(inp.data)
+    flag_arr[inp.mask] = QartodFlags.MISSING
+    valid = ~inp.mask
+
+    #   Assign first point to be basically unchanging
+    diff_inp = np.ma.zeros(inp.size, dtype=float)
+    diff_inp[1:] = np.diff(inp)
+    if direction == "down":
+        #   Glider is sinking, flag points that are less than 0 w/ pad
+        flag_arr[valid & (diff_inp < pad)] = QartodFlags.SUSPECT
+    elif direction == "up":
+        #   Glider is rising, flag points that are more than 0 w/ pad
+        flag_arr[valid & (diff_inp > -pad)] = QartodFlags.SUSPECT
+    else:
+        msg = f"Missing or unclear definition for `direction`: {direction}.\nShould be 'down' or 'up'."
+        raise ValueError(msg)
+    #   Reassign first point
+    flag_arr[0] = flag_arr[1]
+
+    if assess_floating:
+        #   When a flag is triggered as suspect, set a condition for a tougher breakout padding value.
+        #   Init boolean is(1)/isnot(0) floating array
+        floating_ix = np.zeros(diff_inp.size, dtype=bool)
+
+        is_floating = False
+        for i, val in enumerate(diff_inp):
+            if not is_floating:
+                if flag_arr[i] == QartodFlags.SUSPECT:
+                    is_floating = True
+                    floating_ix[i] = True
+            else:
+                if direction == "down" and val >= breakout:
+                    is_floating = False
+                elif direction =="up" and val <= -breakout:
+                    is_floating = False
+                else:
+                    floating_ix[i] = True
+        flag_arr[valid & floating_ix] = QartodFlags.SUSPECT
+
+    return flag_arr.reshape(original_shape)
+
+
+@add_flag_metadata(
     standard_name="density_inversion_test_flag",
     long_name="Density Inversion Test Flag",
 )

--- a/ioos_qc/qartod.py
+++ b/ioos_qc/qartod.py
@@ -1209,6 +1209,7 @@ def pressure_test(
     inp: Sequence[Real],
     direction: str,
     pad: float = 0.01,
+    *,
     assess_floating: bool = False,
     breakout: float = 0.025,
 ) -> np.ma.core.MaskedArray:

--- a/tests/test_argo.py
+++ b/tests/test_argo.py
@@ -128,6 +128,7 @@ class ArgoSpeedTest(unittest.TestCase):
                 fail_threshold=self.fail_threshold,
             )
 
+
 def test_argo_pressure_increasing_names():
     assert argo.pressure_increasing_test.long_name == "Pressure Increasing Test Quality Flag"
     assert argo.pressure_increasing_test.standard_name == "pressure_increasing_test_quality_flag"
@@ -221,6 +222,7 @@ class ArgoPressureIncreasingTest(unittest.TestCase):
         with pytest.raises(ValueError, match=r"'Direction' argument*"):
             argo.pressure_increasing_test(np.array([1]), direction="dow n")
             argo.pressure_increasing_test(np.array([1]), direction=3)
+
 
 class ArgoDuplicateTimeTest:
     def test_all(self):

--- a/tests/test_argo.py
+++ b/tests/test_argo.py
@@ -172,7 +172,9 @@ class ArgoPressureIncreasingTest(unittest.TestCase):
         flags = argo.pressure_increasing_test(pressure, direction="auto")
         npt.assert_array_equal(flags, np.array([1, 1, 1, 1, 1, 1, 1, 1]))
 
-    def test_auto_down(self):
+        npt.assert_array_equal(flags, argo.pressure_increasing_test(pressure, direction="down"))
+
+    def test_auto_up(self):
         # Sign should be negative for array - auto should have same results as "up"
         pressure = np.array(
             [0.0, 2.0, 2.1, 2.12, 2.3, 4.0, 14.2, 20.0],
@@ -181,6 +183,8 @@ class ArgoPressureIncreasingTest(unittest.TestCase):
         pressure = pressure[::-1]
         flags = argo.pressure_increasing_test(pressure, direction="auto")
         npt.assert_array_equal(flags, np.array([1, 1, 1, 1, 1, 1, 1, 1]))
+
+        npt.assert_array_equal(flags, argo.pressure_increasing_test(pressure, direction="up"))
 
     def test_pressure_shallow(self):
         # Shallow profiles should be flagged if it's stuck or decreasing

--- a/tests/test_argo.py
+++ b/tests/test_argo.py
@@ -161,7 +161,7 @@ class ArgoPressureIncreasingTest(unittest.TestCase):
         )
         pressure = pressure[::-1]
         flags = argo.pressure_increasing_test(pressure, direction="up", pres_reversal=0.0)
-        npt.assert_array_equal(flags, np.array([4, 1, 1, 1, 1, 1, 1, 1]))
+        npt.assert_array_equal(flags, np.array([1, 1, 1, 1, 1, 1, 1, 4]))
 
     def test_auto_down(self):
         # Sign should be positive for array - auto should have same results as "down"

--- a/tests/test_argo.py
+++ b/tests/test_argo.py
@@ -221,6 +221,7 @@ class ArgoPressureIncreasingTest(unittest.TestCase):
     def test_fail(self):
         with pytest.raises(ValueError, match=r"'Direction' argument*"):
             argo.pressure_increasing_test(np.array([1]), direction="dow n")
+        with pytest.raises(ValueError, match=r"'Direction' argument*"):
             argo.pressure_increasing_test(np.array([1]), direction=3)
 
 

--- a/tests/test_argo.py
+++ b/tests/test_argo.py
@@ -128,6 +128,10 @@ class ArgoSpeedTest(unittest.TestCase):
                 fail_threshold=self.fail_threshold,
             )
 
+def test_argo_pressure_increasing_names():
+    assert argo.pressure_increasing_test.long_name == "Pressure Increasing Test Quality Flag"
+    assert argo.pressure_increasing_test.standard_name == "pressure_increasing_test_quality_flag"
+
 
 class ArgoPressureIncreasingTest(unittest.TestCase):
     def test_pressure_downcast(self):
@@ -136,7 +140,7 @@ class ArgoPressureIncreasingTest(unittest.TestCase):
             [0.0, 2.0, 2.1, 2.12, 2.3, 4.0, 14.2, 20.0],
             dtype="float32",
         )
-        flags = argo.pressure_increasing_test(pressure)
+        flags = argo.pressure_increasing_test(pressure, direction="down")
         npt.assert_array_equal(flags, np.array([1, 1, 1, 1, 1, 1, 1, 1]))
 
     def test_pressure_upcast(self):
@@ -146,7 +150,35 @@ class ArgoPressureIncreasingTest(unittest.TestCase):
             dtype="float32",
         )
         pressure = pressure[::-1]
-        flags = argo.pressure_increasing_test(pressure)
+        flags = argo.pressure_increasing_test(pressure, direction="up")
+        npt.assert_array_equal(flags, np.array([1, 1, 1, 1, 1, 1, 1, 1]))
+
+    def test_press_upcast_w_bad(self):
+        pressure = np.array(
+            [14.0, 2.0, 2.1, 2.12, 2.3, 4.0, 14.2, 20.0],
+            dtype="float32",
+        )
+        pressure = pressure[::-1]
+        flags = argo.pressure_increasing_test(pressure, direction="up", pres_reversal=0.0)
+        npt.assert_array_equal(flags, np.array([4, 1, 1, 1, 1, 1, 1, 1]))
+
+    def test_auto_down(self):
+        # Sign should be positive for array - auto should have same results as "down"
+        pressure = np.array(
+            [0.0, 2.0, 2.1, 2.12, 2.3, 4.0, 14.2, 20.0],
+            dtype="float32",
+        )
+        flags = argo.pressure_increasing_test(pressure, direction="auto")
+        npt.assert_array_equal(flags, np.array([1, 1, 1, 1, 1, 1, 1, 1]))
+
+    def test_auto_down(self):
+        # Sign should be negative for array - auto should have same results as "up"
+        pressure = np.array(
+            [0.0, 2.0, 2.1, 2.12, 2.3, 4.0, 14.2, 20.0],
+            dtype="float32",
+        )
+        pressure = pressure[::-1]
+        flags = argo.pressure_increasing_test(pressure, direction="auto")
         npt.assert_array_equal(flags, np.array([1, 1, 1, 1, 1, 1, 1, 1]))
 
     def test_pressure_shallow(self):
@@ -155,13 +187,13 @@ class ArgoPressureIncreasingTest(unittest.TestCase):
             [0.0, 2.0, 2.0, 1.99, 2.3, 2.4, 2.4, 2.5],
             dtype="float32",
         )
-        flags = argo.pressure_increasing_test(pressure)
-        npt.assert_array_equal(flags, np.array([1, 1, 3, 3, 1, 1, 3, 1]))
+        flags = argo.pressure_increasing_test(pressure, direction="down", pres_reversal=0)
+        npt.assert_array_equal(flags, np.array([1, 1, 4, 4, 1, 1, 4, 1]))
 
     def test_using_config(self):
         config = {
             "argo": {
-                "pressure_increasing_test": {},
+                "pressure_increasing_test": {"direction": "down", "pres_reversal": 0},
             },
         }
 
@@ -173,7 +205,7 @@ class ArgoPressureIncreasingTest(unittest.TestCase):
             ),
         )
 
-        expected = np.array([1, 1, 3, 3, 1, 1, 3, 1])
+        expected = np.array([1, 1, 4, 4, 1, 1, 4, 1])
         npt.assert_array_equal(
             r["argo"]["pressure_increasing_test"],
             expected,
@@ -185,6 +217,10 @@ class ArgoPressureIncreasingTest(unittest.TestCase):
         flags = gliders.pressure_check(pressure)
         npt.assert_array_equal(flags, np.array([1, 1, 1]))
 
+    def test_fail(self):
+        with pytest.raises(ValueError, match=r"'Direction' argument*"):
+            argo.pressure_increasing_test(np.array([1]), direction="dow n")
+            argo.pressure_increasing_test(np.array([1]), direction=3)
 
 class ArgoDuplicateTimeTest:
     def test_all(self):

--- a/tests/test_qartod.py
+++ b/tests/test_qartod.py
@@ -2013,31 +2013,20 @@ PRES_ARR = np.array([1, 1.009, 1.02, 2, np.nan, 2.001, 7, 0, 2])
 
 
 @pytest.mark.parametrize(
-    ("data", "direction", "pad", "assess_floating", "breakout", "expected"),
+    ("data", "direction", "kwargs", "expected"),
     [
-        (PRES_ARR, "down", None, None, None, [3, 3, 1, 1, 9, 1, 1, 3, 1]),
-        (PRES_ARR, "up", None, None, None, [3, 3, 3, 3, 9, 1, 3, 1, 3]),
-        (PRES_ARR, "down", 0.0, None, None, [1, 1, 1, 1, 9, 1, 1, 3, 1]),
-        (PRES_ARR, "down", 1, None, None, [3, 3, 3, 3, 9, 1, 1, 3, 1]),
-        (PRES_ARR, "down", None, True, None, [3, 3, 3, 1, 9, 1, 1, 3, 1]),
-        (PRES_ARR, "down", None, True, 1, [3, 3, 3, 3, 9, 3, 1, 3, 1]),
+        (PRES_ARR, "down", {}, [3, 3, 1, 1, 9, 1, 1, 3, 1]),
+        (PRES_ARR, "up", {}, [3, 3, 3, 3, 9, 1, 3, 1, 3]),
+        (PRES_ARR, "down", {"pad": 0.0}, [1, 1, 1, 1, 9, 1, 1, 3, 1]),
+        (PRES_ARR, "down", {"pad": 1}, [3, 3, 3, 3, 9, 1, 1, 3, 1]),
+        (PRES_ARR, "down", {"assess_floating": True}, [3, 3, 3, 1, 9, 1, 1, 3, 1]),
+        (PRES_ARR, "down", {"assess_floating": True, "breakout": 1}, [3, 3, 3, 3, 9, 3, 1, 3, 1]),
     ],
 )
-def test_pressure_good(data, direction, pad, assess_floating, breakout, expected):
-    kwargs = {}
-    if pad is not None:
-        kwargs["pad"] = pad
-    if assess_floating is not None:
-        kwargs["assess_floating"] = assess_floating
-    if breakout is not None:
-        kwargs["breakout"] = breakout
-
+def test_pressure_good(data, direction, kwargs, expected):
     flags = qartod.pressure_test(data, direction, **kwargs)
 
-    npt.assert_array_equal(
-        flags.data,
-        expected,
-    )
+    npt.assert_array_equal(flags.data, expected)
 
 
 def test_pressure_errors():

--- a/tests/test_qartod.py
+++ b/tests/test_qartod.py
@@ -2043,6 +2043,7 @@ def test_pressure_good(data, direction, pad, assess_floating, breakout, expected
 def test_pressure_errors():
     with pytest.raises(ValueError, match=r"Missing or unclear definition for*"):
         qartod.pressure_test(np.array([1]), direction="dow n")
+    with pytest.raises(ValueError, match=r"Missing or unclear definition for*"):
         qartod.pressure_test(np.array([1]), direction=3)
 
 

--- a/tests/test_qartod.py
+++ b/tests/test_qartod.py
@@ -2015,12 +2015,12 @@ PRES_ARR = np.array([1, 1.009, 1.02, 2, np.nan, 2.001, 7, 0, 2])
 @pytest.mark.parametrize(
     ("data", "direction", "pad", "assess_floating", "breakout", "expected"),
     [
-        (PRES_ARR,"down",None,None,None,[3,3,1,1,9,1,1,3,1,],),
-        (PRES_ARR,"up",None,None,None,[3,3,3,3,9,1,3,1,3,],),
-        (PRES_ARR,"down",0.0,None,None,[1,1,1,1,9,1,1,3,1],),
-        (PRES_ARR,"down",1,None,None,[3,3,3,3,9,1,1,3,1],),
-        (PRES_ARR,"down",None,True,None,[3,3,3,1,9,1,1,3,1],),
-        (PRES_ARR,"down",None,True,1,[3,3,3,3,9,3,1,3,1],),
+        (PRES_ARR, "down", None, None, None, [3, 3, 1, 1, 9, 1, 1, 3, 1]),
+        (PRES_ARR, "up", None, None, None, [3, 3, 3, 3, 9, 1, 3, 1, 3]),
+        (PRES_ARR, "down", 0.0, None, None, [1, 1, 1, 1, 9, 1, 1, 3, 1]),
+        (PRES_ARR, "down", 1, None, None, [3, 3, 3, 3, 9, 1, 1, 3, 1]),
+        (PRES_ARR, "down", None, True, None, [3, 3, 3, 1, 9, 1, 1, 3, 1]),
+        (PRES_ARR, "down", None, True, 1, [3, 3, 3, 3, 9, 3, 1, 3, 1]),
     ],
 )
 def test_pressure_good(data, direction, pad, assess_floating, breakout, expected):

--- a/tests/test_qartod.py
+++ b/tests/test_qartod.py
@@ -2009,6 +2009,48 @@ class QartodAttenuatedSignalTest(unittest.TestCase):
         )
 
 
+PRES_ARR = np.array([1, 1.009, 1.02, 2, np.nan, 2.001, 7, 0, 2])
+
+
+@pytest.mark.parametrize(
+    ("data", "direction", "pad", "assess_floating", "breakout", "expected"),
+    [
+        (PRES_ARR,"down",None,None,None,[3,3,1,1,9,1,1,3,1,],),
+        (PRES_ARR,"up",None,None,None,[3,3,3,3,9,1,3,1,3,],),
+        (PRES_ARR,"down",0.0,None,None,[1,1,1,1,9,1,1,3,1],),
+        (PRES_ARR,"down",1,None,None,[3,3,3,3,9,1,1,3,1],),
+        (PRES_ARR,"down",None,True,None,[3,3,3,1,9,1,1,3,1],),
+        (PRES_ARR,"down",None,True,1,[3,3,3,3,9,3,1,3,1],),
+    ],
+)
+def test_pressure_good(data, direction, pad, assess_floating, breakout, expected):
+    kwargs = {}
+    if pad is not None:
+        kwargs["pad"] = pad
+    if assess_floating is not None:
+        kwargs["assess_floating"] = assess_floating
+    if breakout is not None:
+        kwargs["breakout"] = breakout
+
+    flags = qartod.pressure_test(data, direction, **kwargs)
+
+    npt.assert_array_equal(
+        flags.data,
+        expected,
+    )
+
+
+def test_pressure_errors():
+    with pytest.raises(ValueError, match=r"Missing or unclear definition for*"):
+        qartod.pressure_test(np.array([1]), direction="dow n")
+        qartod.pressure_test(np.array([1]), direction=3)
+
+
+def test_pressure_names():
+    assert qartod.pressure_test.long_name == "Pressure Test Quality Flag"
+    assert qartod.pressure_test.standard_name == "pressure_test_quality_flag"
+
+
 class QartodDensityInversionTest(unittest.TestCase):
     def _run_density_inversion_tests(
         self,


### PR DESCRIPTION
This PR reviews the `pressure_test` as described in the [QARTOD glider QC manual.](https://cdn.ioos.noaa.gov/media/2017/12/Manual-for-QC-of-Glider-Data_05_09_16.pdf)

* Adds a QARTOD-specified function `pressure_test` to `qartod.py`, utilizing additional arguments to specify if pressure points are "relatively" static or floating.
  * Monotonic relative to previous points (recursively described in manual) if `pad = 0.0`
* Reworks the `argo.pressure_increasing_test` to be more representative of the Argo manual
  * Use cumulative min/max pressure values
  * Flag as FAIL
  * Add optional kwargs such that workflows are not immediately broken. Default `pres_reversal=20` to that given in the Argo manual example.

This is related to part of issue #112.

Documentation on the assessment process is available at the [Deliverable 2 notebook](https://github.com/Klankers/mau_gsoc_qartod/blob/main/deliverable_2.ipynb).

Other tests, namely `climatology_test` and `density_inversion_test` have been moved to GSoC Deliverable 3 (as they are not "required" tests). This PR thus concludes work on Deliverable 2.