### PR TITLE
fix input check in climatology test

### DIFF
--- a/ioos_qc/qartod.py
+++ b/ioos_qc/qartod.py
@@ -697,8 +697,7 @@ class ClimatologyConfig:
                 tinp_copy = tinp
 
             # If a zspan is defined but we don't have z input (zinp), skip this member
-            # Note: `zinp.count()` can return `np.ma.masked` so we also check using isnan
-            if not isnan(m.zspan) and (not zinp.count() or isnan(zinp.any())):
+            if not isnan(m.zspan) and not zinp.count():
                 continue
 
             # Indexes that align with the T


### PR DESCRIPTION
Remove the redundant `isnan(zinp.any())` check and the related comment from the climatology test.

This addresses #204