### PR TITLE
Allow rate_of_change_test to derive its threshold from the data (N_DEV/TIM_DEV)

### DIFF
--- a/ioos_qc/qartod.py
+++ b/ioos_qc/qartod.py
@@ -923,11 +923,14 @@ def spike_test(
     standard_name="rate_of_change_test_quality_flag",
     long_name="Rate of Change Test Quality Flag",
 )
-def rate_of_change_test(
+def rate_of_change_test(  # noqa: PLR0913, PLR0917
     inp: Sequence[Real],
     tinp: Sequence[Real],
-    threshold: float,
+    threshold: float | None = None,
     fail_threshold: float | None = None,
+    n_dev: float | None = None,
+    tim_dev: Real | None = None,
+    min_periods: int | None = None,
 ) -> np.ma.core.MaskedArray:
     """Checks the first order difference of a series of values to see if
     there are any values exceeding a threshold defined by the inputs.
@@ -954,6 +957,36 @@ def rate_of_change_test(
     fail_threshold
         A float value representing a rate of change over time, in observation units per second.
         Rates exceeding this will be flagged as FAIL.
+    n_dev
+        Number of standard deviations, `N_DEV` in the QARTOD manual. Supply together
+        with `tim_dev` instead of `threshold` to derive the threshold from the data
+        rather than fixing it. Mutually exclusive with `threshold`.
+    tim_dev
+        Length of the trailing window over which the standard deviation is computed,
+        in seconds. `TIM_DEV` in the QARTOD manual, whose example uses a 25 hour
+        window to accommodate diurnal and tidal cycles.
+    min_periods
+        Minimum number of observations in the `tim_dev` window required before a
+        threshold is computed [optional]. Points with fewer observations behind them
+        are left as GOOD, since there is not yet enough history to judge them.
+
+    Notes
+    -----
+    Two ways of choosing the threshold are supported, per the QARTOD Manual for
+    Real-Time Quality Control of In-situ Temperature and Salinity Data, Test 7.
+
+    With `threshold`, the first order difference is divided by the elapsed time and
+    compared against a fixed rate in observation units per second. This is the
+    original behaviour and is unchanged.
+
+    With `n_dev` and `tim_dev`, the manual's codable instruction is used instead::
+
+        If |T(n) - T(n-1)| > N_DEV * SD, flag = 3
+
+    where `SD` is the standard deviation of the observations over the preceding
+    `tim_dev` seconds. Note this compares an absolute difference rather than a rate.
+    The manual states "No fail flag is identified for this test", so `fail_threshold`
+    does not apply in this mode.
 
     Returns
     -------
@@ -961,6 +994,18 @@ def rate_of_change_test(
         A masked array of flag values equal in size to that of the input.
 
     """
+    derived = n_dev is not None or tim_dev is not None
+    if derived:
+        if threshold is not None:
+            msg = "Supply either `threshold` or `n_dev`/`tim_dev`, not both"
+            raise ValueError(msg)
+        if n_dev is None or tim_dev is None:
+            msg = "`n_dev` and `tim_dev` must be supplied together"
+            raise ValueError(msg)
+    elif threshold is None:
+        msg = "Supply either `threshold` or both `n_dev` and `tim_dev`"
+        raise ValueError(msg)
+
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
         inp = np.ma.masked_invalid(np.array(inp).astype(np.float64))
@@ -972,21 +1017,46 @@ def rate_of_change_test(
     # Start with everything as passing (1)
     flag_arr = np.ma.ones(inp.size, dtype="uint8")
 
-    # calculate rate of change in units/second
-    roc = np.ma.zeros(inp.size, dtype="float")
-
     tinp = mapdates(tinp).flatten()
-    roc[1:] = np.abs(
-        np.diff(inp) / np.diff(tinp).astype("timedelta64[s]").astype(float),
-    )
 
-    with np.errstate(invalid="ignore"):
-        flag_arr[roc > threshold] = QartodFlags.SUSPECT
+    if derived:
+        # QARTOD Test 7, Example 2: If |T(n) - T(n-1)| > N_DEV * SD, flag = 3.
+        # SD is taken over the preceding tim_dev seconds, so the comparison is
+        # against an absolute difference rather than a rate.
+        diff = np.ma.zeros(inp.size, dtype="float")
+        diff[1:] = np.abs(np.diff(inp))
 
-    # the fail threshold is optional and only required for some use cases
-    if fail_threshold is not None:
+        series = pd.Series(inp.filled(np.nan), index=tinp)
+        # closed="left" excludes the point under test, so a large excursion does
+        # not inflate the standard deviation it is being compared against. The
+        # manual computes SD over "the previous" tim_dev period.
+        sd = series.rolling(
+            f"{tim_dev}s",
+            min_periods=min_periods,
+            closed="left",
+        ).std(ddof=0)
+        limit = n_dev * np.asarray(sd, dtype="float")
+
         with np.errstate(invalid="ignore"):
-            flag_arr[roc > fail_threshold] = QartodFlags.FAIL
+            exceeds = diff > limit
+        # A NaN limit means the window held too little history to judge the point.
+        exceeds &= ~np.isnan(limit)
+        exceeds[0] = False
+        flag_arr[exceeds] = QartodFlags.SUSPECT
+    else:
+        # calculate rate of change in units/second
+        roc = np.ma.zeros(inp.size, dtype="float")
+        roc[1:] = np.abs(
+            np.diff(inp) / np.diff(tinp).astype("timedelta64[s]").astype(float),
+        )
+
+        with np.errstate(invalid="ignore"):
+            flag_arr[roc > threshold] = QartodFlags.SUSPECT
+
+        # the fail threshold is optional and only required for some use cases
+        if fail_threshold is not None:
+            with np.errstate(invalid="ignore"):
+                flag_arr[roc > fail_threshold] = QartodFlags.FAIL
 
     # If the value is masked set the flag to MISSING
     flag_arr[inp.mask] = QartodFlags.MISSING

--- a/tests/test_qartod.py
+++ b/tests/test_qartod.py
@@ -1440,6 +1440,84 @@ class QartodRateOfChangeTest(unittest.TestCase):
         )
         npt.assert_array_equal(expected, result)
 
+    def test_rate_of_change_n_dev(self):
+        """Threshold derived from the data, per QARTOD Test 7 Example 2:
+        if |T(n) - T(n-1)| > N_DEV * SD, flag = 3.
+        """
+        times = np.arange(
+            "2015-01-01 00:00:00",
+            "2015-01-01 12:00:00",
+            step=np.timedelta64(1, "h"),
+            dtype=np.datetime64,
+        )
+        # steady around 10 with a single large excursion at index 9
+        arr = [10, 10.1, 9.9, 10.05, 9.95, 10.0, 10.1, 9.9, 10.0, 20.0, 10.1, 10.0]
+        expected = [1, 1, 1, 1, 1, 1, 1, 1, 1, 3, 1, 1]
+        result = qartod.rate_of_change_test(
+            inp=arr,
+            tinp=times,
+            n_dev=3,
+            tim_dev=6 * 3600,
+            min_periods=3,
+        )
+        npt.assert_array_equal(result, expected)
+
+    def test_rate_of_change_n_dev_excludes_point_under_test(self):
+        """The standard deviation is taken over the *preceding* window. If the
+        point under test were included it would inflate the deviation it is
+        compared against and never be flagged.
+        """
+        times = np.arange(
+            "2015-01-01 00:00:00",
+            "2015-01-01 12:00:00",
+            step=np.timedelta64(1, "h"),
+            dtype=np.datetime64,
+        )
+        arr = [10, 10.1, 9.9, 10.05, 9.95, 10.0, 10.1, 9.9, 10.0, 20.0, 10.1, 10.0]
+        result = qartod.rate_of_change_test(
+            inp=arr,
+            tinp=times,
+            n_dev=3,
+            tim_dev=6 * 3600,
+            min_periods=3,
+        )
+        assert result[9] == qartod.QartodFlags.SUSPECT
+
+    def test_rate_of_change_n_dev_no_fail_flag(self):
+        """The manual states "No fail flag is identified for this test", so the
+        derived mode never raises FAIL however large the excursion.
+        """
+        times = np.arange(
+            "2015-01-01 00:00:00",
+            "2015-01-01 12:00:00",
+            step=np.timedelta64(1, "h"),
+            dtype=np.datetime64,
+        )
+        arr = [10, 10.1, 9.9, 10.05, 9.95, 10.0, 10.1, 9.9, 10.0, 5000.0, 10.1, 10.0]
+        result = qartod.rate_of_change_test(
+            inp=arr,
+            tinp=times,
+            n_dev=3,
+            tim_dev=6 * 3600,
+            min_periods=3,
+        )
+        assert qartod.QartodFlags.FAIL not in result
+
+    def test_rate_of_change_argument_validation(self):
+        times = self.times
+        arr = [1] * len(times)
+        for kwargs in (
+            {"threshold": self.threshold, "n_dev": 3, "tim_dev": 3600},
+            {"n_dev": 3},
+            {"tim_dev": 3600},
+            {},
+        ):
+            with (
+                self.subTest(kwargs=kwargs),
+                pytest.raises(ValueError, match=r"threshold|tim_dev"),
+            ):
+                qartod.rate_of_change_test(inp=arr, tinp=times, **kwargs)
+
     def test_rate_of_change_fail_flag(self):
         """Test of optional fail flag."""
         times = self.times


### PR DESCRIPTION
Fixes #44

@kwilcox on the issue:

> I'd be happy to accept a PR that accepts both a computed `threshold` parameter
> and the `N_DEV` / `TIM_DEV` parameter as inputs

That's what this does. `threshold` is unchanged and remains the default path;
`n_dev` / `tim_dev` are new and optional.

### What the manual specifies

QARTOD Manual for Real-Time Quality Control of In-situ Temperature and Salinity
Data, Test 7, Example 2 — the codable instruction is:

> **Suspect=3** — If `|T(n) – T(n-1)| > N_DEV*SD`, flag = 3
> Example: `N_DEV = 3`, `TIM_DEV = 25`

with `SD` computed over the previous `TIM_DEV` period. Note the comparison is
against an **absolute difference**, not a rate — which is the difference @petejan
raised. The existing rate-based path is untouched, so both are now available.

The manual also says *"No fail flag is identified for this test"*, so the derived
mode only ever raises SUSPECT and `fail_threshold` does not apply to it.

### Detail worth reviewing

The standard deviation is taken with `closed="left"`, excluding the point under
test from its own window. Without that, a large excursion inflates the deviation
it is compared against and is never flagged — the test misses exactly the points
it exists to catch. There is a test pinning this.

`tim_dev` is in **seconds**, matching `test_period` in `attenuated_signal_test`,
which uses the same `pd.Series(...).rolling(f"{n}s").std(ddof=0)` pattern.

One consequence of the method, which the manual acknowledges (*"upon failure, it
is unknown which of the points is bad"*): the point returning from an excursion
is usually not flagged, because by then the excursion is inside its SD window.

### Deliberately not included

The later comments on the issue raised applying the test along other axes
(depth, lat, lon) and the overlap with the spike test. Both are separate
questions from the one @kwilcox scoped, so they are not touched here.

### Tests

Four added to `QartodRateOfChangeTest`:

| Test | Checks |
|---|---|
| `test_rate_of_change_n_dev` | full flag array for a series with one excursion |
| `test_rate_of_change_n_dev_excludes_point_under_test` | the `closed="left"` behaviour above |
| `test_rate_of_change_n_dev_no_fail_flag` | no FAIL even for a 500× excursion |
| `test_rate_of_change_argument_validation` | all four invalid argument combinations |

All four fail without the implementation. Existing `rate_of_change` tests are
unmodified and still pass.

Suite: **173 passed**. The 3 failures are `location` tests needing the optional
`roaring_landmask` package and are identical on `main`. `ruff check` and
`ruff format --check` clean.

---

Two things you should weigh, since I'm coming to this cold:

- The direction I followed is @kwilcox's from 2021, and the issue has been quiet
  since. If the project's thinking has moved on, say so and I'll rework or close.
- `# noqa: PLR0913, PLR0917` is on the signature, matching `attenuated_signal_test`.
  If you'd rather the new parameters were keyword-only instead, that's a small change.
