### PR TITLE
Density inversion

### DIFF
--- a/ioos_qc/qartod.py
+++ b/ioos_qc/qartod.py
@@ -1362,6 +1362,29 @@ def density_inversion_test(
     flag_arr
         A masked array of flag values equal in size to that of the input.
 
+    Example
+    -------
+    Because this test does not know if the first or second point exeeds is responsible when a change in density
+    is triggered, it flags both points surrounding said change in density. The same goes for NaN values.
+    
+    >>> pressure = [0,    5,     10,   15,    20,     25,   20,    15,   10,   5,     0   ]
+    >>> sigma0 =   [14.5, 14.52, 15.1, 15.15, np.nan, 15.7, 15.65, 15.0, 16.1, 15.12, 14.5]
+    >>> flags = qartod.density_inversion_test(sigma0, pressure, suspect_threshold=0.03, fail_threshold=0.01)
+    >>> flags
+    masked_array(data=[3, 3, 1, 1, 9, 9, 1, 4, 4, 1, 1],
+             mask=False,
+       fill_value=999999)
+
+    Flags are applied in the order PASS, SUSPECT, FAIL, and MISSING. Due to multiple flags being written,
+    it is possible for flags to be overwritten (1 --> 3 --> 4).
+
+    >>> sigma0 =   [14.5, 14.52, 15.1, 15.15, np.nan, 15.7, 15.65, 15.0, 16.1, 16.08, 14.5]
+    >>> flags = qartod.density_inversion_test(sigma0, pressure, suspect_threshold=0.03, fail_threshold=0.01)
+    >>> flags
+    masked_array(data=[3, 3, 1, 1, 9, 9, 1, 4, 4, 3, 1],
+             mask=False,
+       fill_value=999999)
+    
     """
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")

--- a/ioos_qc/qartod.py
+++ b/ioos_qc/qartod.py
@@ -1364,9 +1364,9 @@ def density_inversion_test(
 
     Example
     -------
-    Because this test does not know if the first or second point exeeds is responsible when a change in density
+    Because this test does not know if the first or second point exceeds is responsible when a change in density
     is triggered, it flags both points surrounding said change in density. The same goes for NaN values.
-    
+
     >>> pressure = [0,    5,     10,   15,    20,     25,   20,    15,   10,   5,     0   ]
     >>> sigma0 =   [14.5, 14.52, 15.1, 15.15, np.nan, 15.7, 15.65, 15.0, 16.1, 15.12, 14.5]
     >>> flags = qartod.density_inversion_test(sigma0, pressure, suspect_threshold=0.03, fail_threshold=0.01)
@@ -1384,7 +1384,7 @@ def density_inversion_test(
     masked_array(data=[3, 3, 1, 1, 9, 9, 1, 4, 4, 3, 1],
              mask=False,
        fill_value=999999)
-    
+
     """
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")

--- a/tests/test_qartod.py
+++ b/tests/test_qartod.py
@@ -2169,6 +2169,22 @@ class QartodDensityInversionTest(unittest.TestCase):
         result = [1, 9, 9, 1, 1]
         self._run_density_inversion_tests(density, depth, result)
 
+    def test_density_inversion_len_zero(self):
+        flags = qartod.density_inversion_test(
+            inp = np.arange(0),
+            zinp = np.arange(0)
+        )
+        assert isinstance(flags, np.ma.MaskedArray)
+        assert flags.size == 0
+
+        match = "must be the same shape"
+        with pytest.raises(ValueError, match=match):
+            flags = qartod.density_inversion_test(
+                inp = np.arange(0),
+                zinp = np.arange(1)
+            )
+        
+
     def test_density_inversion_input(self):
         density = [1024, 1024, 1025]
         depth = [1, 2, 3]

--- a/tests/test_qartod.py
+++ b/tests/test_qartod.py
@@ -2170,20 +2170,13 @@ class QartodDensityInversionTest(unittest.TestCase):
         self._run_density_inversion_tests(density, depth, result)
 
     def test_density_inversion_len_zero(self):
-        flags = qartod.density_inversion_test(
-            inp = np.arange(0),
-            zinp = np.arange(0)
-        )
+        flags = qartod.density_inversion_test(inp=np.arange(0), zinp=np.arange(0))
         assert isinstance(flags, np.ma.MaskedArray)
         assert flags.size == 0
 
         match = "must be the same shape"
         with pytest.raises(ValueError, match=match):
-            flags = qartod.density_inversion_test(
-                inp = np.arange(0),
-                zinp = np.arange(1)
-            )
-        
+            flags = qartod.density_inversion_test(inp=np.arange(0), zinp=np.arange(1))
 
     def test_density_inversion_input(self):
         density = [1024, 1024, 1025]


### PR DESCRIPTION
This PR assesses the `density_inversion_test`. In doing so, issues #244 , #245 , and #246 were identified.

This test is in good shape and the codebase is perhaps better than the manual describes it as. I had some confusion in using it correctly but otherwise it appears to be highly functional and no major changes are necessary.
* Added an example to the docstring.
* Added a few lines of coverage to the unit tests.

Additional documentation is available at [GSoC deliverable #3](https://github.com/Klankers/mau_gsoc_qartod/blob/main/deliverable_3.ipynb).

As per the documentation at the link above, the only major test remaining is the `climatology` test. Any other tests are considered a bonus. A final notebook submission, capturing some of the key insights from GSoC, should also be prepared for the IOOS Code Lab as a final deliverable.
